### PR TITLE
feat: Add fanin and fanout operators

### DIFF
--- a/brat/Brat/Checker.hs
+++ b/brat/Brat/Checker.hs
@@ -495,7 +495,7 @@ check' FanOut ((p, ty):overs, ()) = do
           wires <- fanoutNodes ?my n (p, valueToBinder ?my ty) elTy
           pure (((), wires), (overs, ()))
       | otherwise -> typeErr $ "Can't fanout a Vec with non-constant length: " ++ show n
-    _ -> typeErr "Fanout only applies to Vec"
+    _ -> typeErr "Fanout ([/\\]) only applies to Vec"
  where
   fanoutNodes :: Modey m -> Integer -> (Src, BinderType m) -> Val Z -> Checking [(Src, BinderType m)]
   fanoutNodes _ 0 _ _ = pure []
@@ -517,7 +517,7 @@ check' FanIn (overs, ((tgt, ty):unders)) = do
           overs <- faninNodes ?my n (tgt, valueToBinder ?my ty) elTy overs
           pure (((), ()), (overs, unders))
       | otherwise -> typeErr $ "Can't fanout a Vec with non-constant length: " ++ show n
-    _ -> typeErr "Fanout only applies to Vec"
+    _ -> typeErr "Fanin ([\\/]) only applies to Vec"
  where
   faninNodes :: Modey m
              -> Integer             -- The number of things left to pack up

--- a/brat/Brat/Elaborator.hs
+++ b/brat/Brat/Elaborator.hs
@@ -184,6 +184,8 @@ elaborate' (FKernel sty) = pure $ SomeRaw' (RKernel sty)
 -- We catch underscores in the top-level elaborate so this case
 -- should never be triggered
 elaborate' FUnderscore = Left (dumbErr (InternalError "Unexpected '_'"))
+elaborate' FFanOut = pure $ SomeRaw' RFanOut
+elaborate' FFanIn = pure $ SomeRaw' RFanIn
 
 elabBody :: FBody -> FC -> Either Error (FunBody Raw Noun)
 elabBody (FClauses cs) fc = ThunkOf . WC fc . Clauses <$> traverse elab1Clause cs

--- a/brat/Brat/Error.hs
+++ b/brat/Brat/Error.hs
@@ -80,6 +80,10 @@ data ErrorMsg
  | WrongModeForType String
  -- TODO: Add file context here
  | CompilingHoles [String]
+ -- For thunks which don't address enough inputs, or produce enough outputs.
+ -- The argument is the row of unused connectors
+ | ThunkLeftOvers String
+ | ThunkLeftUnders String
 
 instance Show ErrorMsg where
   show (TypeErr x) = "Type error: " ++ x
@@ -164,6 +168,9 @@ instance Show ErrorMsg where
   show (CompilingHoles hs) = unlines ("Can't compile file with remaining holes": indent hs)
    where
     indent = fmap ("  " ++)
+  show (ThunkLeftOvers overs) = "Expected function to address all inputs, but " ++ overs ++ " wasn't used"
+  show (ThunkLeftUnders unders) = "Expected function to return additional values of type: " ++ unders
+
 
 data Error = Err { fc  :: Maybe FC
                  , msg :: ErrorMsg

--- a/brat/Brat/Eval.hs
+++ b/brat/Brat/Eval.hs
@@ -256,7 +256,10 @@ eqWorker tm lvkz (TypeFor _ []) (SSum m0 stk0 rs0) (SSum m1 stk1 rs1)
       Just rs -> traverse eqVariant rs <&> sequence_
  where
   eqVariant (Some r0, Some r1) = eqRowTest m0 tm lvkz (stk0,r0) (stk1,r1) <&> dropRight
-eqWorker tm _ _ v0 v1 = pure . Left $ TypeMismatch tm (show v0) (show v1)
+eqWorker tm _ _ s0 s1 = do
+  v0 <- quote Zy s0
+  v1 <- quote Zy s1
+  pure . Left $ TypeMismatch tm (show v0) (show v1)
 
 -- Type rows have bot0,bot1 dangling de Bruijn indices, which we instantiate with
 -- de Bruijn levels. As we go under binders in these rows, we add to the scope's

--- a/brat/Brat/Lexer/Flat.hs
+++ b/brat/Brat/Lexer/Flat.hs
@@ -50,7 +50,7 @@ space = (many $ (satisfy isSpace >> return ()) <|> comment) >> return ()
   comment = string "--" *> ((printChar `manyTill` lookAhead (void newline <|> void eof)) >> return ())
 
 tok :: Lexer Tok
-tok = (   try (char '(' $> LParen)
+tok = try (char '(' $> LParen)
       <|> try (char ')' $> RParen)
       <|> try (char '{' $> LBrace)
       <|> try (char '}' $> RBrace)
@@ -62,6 +62,7 @@ tok = (   try (char '(' $> LParen)
       <|> try (Number <$> number)
       <|> try (string "+" $> Plus)
       <|> try (string "/" $> Slash)
+      <|> try (string "\\" $> Backslash)
       <|> try (string "^" $> Caret)
       <|> try (string "->") $> Arrow
       <|> try (string "=>") $> FatArrow
@@ -89,7 +90,6 @@ tok = (   try (char '(' $> LParen)
       <|> try (K <$> try keyword)
       <|> try qualified
       <|> Ident <$> ident
-      )
  where
   float :: Lexer Double
   float = label "float literal" $ do

--- a/brat/Brat/Lexer/Token.hs
+++ b/brat/Brat/Lexer/Token.hs
@@ -36,6 +36,7 @@ data Tok
  | Plus
  | Minus
  | Asterisk
+ | Backslash
  | Slash
  | Caret
  | Hash
@@ -80,6 +81,7 @@ instance Show Tok where
   show Plus = "+"
   show Minus = "-"
   show Asterisk = "*"
+  show Backslash = "\\"
   show Slash = "/"
   show Caret = "^"
   show Hash = "#"

--- a/brat/Brat/Parser.hs
+++ b/brat/Brat/Parser.hs
@@ -487,12 +487,17 @@ expr' p = choice $ (try . getParser <$> enumFrom p) ++ [atomExpr]
         Nothing -> unWC expr
         Just rest -> FJuxt expr rest
 
+  fanout = square (FFanOut <$ match Slash <* match Backslash)
+  fanin = square (FFanIn <$ match Backslash <* match Slash)
+
   -- Expressions which don't contain juxtaposition or operators
   atomExpr :: Parser Flat
   atomExpr = simpleExpr <|> round expr
    where
     simpleExpr = FHole <$> hole
               <|> try (FSimple <$> simpleTerm)
+              <|> try fanout
+              <|> try fanin
               <|> vec
               <|> cthunk
               <|> try (match DotDot $> FPass)

--- a/brat/Brat/Syntax/Concrete.hs
+++ b/brat/Brat/Syntax/Concrete.hs
@@ -43,4 +43,6 @@ data Flat
  | FKernel RawKType
  | FUnderscore
  | FPass
+ | FFanOut
+ | FFanIn
  deriving Show

--- a/brat/Brat/Syntax/Core.hs
+++ b/brat/Brat/Syntax/Core.hs
@@ -66,6 +66,8 @@ data Term :: Dir -> Kind -> Type where
   C        :: CType' (PortName, KindOr (Term Chk Noun)) -> Term Chk Noun
   -- Kernel types
   K        :: CType' (PortName, Term Chk Noun) -> Term Chk Noun
+  FanOut   :: Term Syn UVerb
+  FanIn    :: Term Chk UVerb
 
 deriving instance Eq (Term d k)
 
@@ -126,6 +128,9 @@ instance Show (Term d k) where
 
   show (C f) = "{" ++ show f ++ "}"
   show (K (ss :-> ts)) = "{" ++ showSig ss ++ " -o " ++ showSig ts ++ "}"
+  show FanOut = "[/\\]"
+  show FanIn = "[\\/]"
+
 
 -- Wrap a term in brackets if its `precedence` is looser than `n`
 bracket :: Precedence -> WC (Term d k) -> String

--- a/brat/Brat/Syntax/Raw.hs
+++ b/brat/Brat/Syntax/Raw.hs
@@ -80,6 +80,8 @@ data Raw :: Dir -> Kind -> Type where
   RFn       :: RawCType -> Raw Chk Noun
   -- Kernel types
   RKernel   :: RawKType -> Raw Chk Noun
+  RFanOut   :: Raw Syn UVerb
+  RFanIn    :: Raw Chk UVerb
 
 class Dirable d where
   dir :: Raw d k -> Diry d
@@ -121,6 +123,8 @@ instance Show (Raw d k) where
   show (RCon c xs) = "Con(" ++ show c ++ "(" ++ show xs ++ "))"
   show (RFn cty) = show cty
   show (RKernel cty) = show cty
+  show RFanOut = "[/\\]"
+  show RFanIn = "[\\/]"
 
 type Desugar = StateT Namespace (ReaderT (RawEnv, Bwd UserName) (Except Error))
 
@@ -235,6 +239,8 @@ instance (Kindable k) => Desugarable (Raw d k) where
   desugar' (RCon c arg) = Con c <$> desugar arg
   desugar' (RFn cty) = C <$> desugar' cty
   desugar' (RKernel cty) = K <$> desugar' cty
+  desugar' RFanOut = pure FanOut
+  desugar' RFanIn = pure FanIn
 
 instance Desugarable ty => Desugarable (PortName, ty) where
   type Desugared (PortName, ty) = (PortName, Desugared ty)

--- a/brat/Brat/Syntax/Value.hs
+++ b/brat/Brat/Syntax/Value.hs
@@ -592,3 +592,11 @@ copyable (VApp _ _) = Just False
 copyable (TVec elem _) = copyable elem
 copyable TBit = Just True
 copyable _ = Nothing
+
+stkLen :: Stack Z t tot -> Ny tot
+stkLen S0 = Zy
+stkLen (zx :<< _) = Sy (stkLen zx)
+
+numValIsConstant :: NumVal (VVar Z) -> Maybe Integer
+numValIsConstant (NumValue up Constant0) = pure up
+numValIsConstant _ = Nothing

--- a/brat/Brat/Unelaborator.hs
+++ b/brat/Brat/Unelaborator.hs
@@ -36,6 +36,8 @@ unelab dy _ (Lambda (abs,rhs) cs) = FLambda ((abs, unelab dy Nouny <$> rhs) :| (
 unelab _ _ (Con c args) = FCon c (unelab Chky Nouny <$> args)
 unelab _ _ (C (ss :-> ts)) = FFn (toRawRo ss :-> toRawRo ts)
 unelab _ _ (K cty) = FKernel $ fmap (\(p, ty) -> Named p (toRaw ty)) cty
+unelab _ _ FanIn = FFanIn
+unelab _ _ FanOut = FFanOut
 
 -- This is needed for concrete terms which embed a type as a list of `Raw` things
 toRaw :: Term d k -> Raw d k
@@ -61,6 +63,8 @@ toRaw (Lambda (abs,rhs) cs) = RLambda (abs, toRaw <$> rhs) (second (fmap toRaw) 
 toRaw (Con c args) = RCon c (toRaw <$> args)
 toRaw (C (ss :-> ts)) = RFn (toRawRo ss :-> toRawRo ts)
 toRaw (K cty) = RKernel $ (\(p, ty) -> Named p (toRaw ty)) <$> cty
+toRaw FanIn = RFanIn
+toRaw FanOut = RFanOut
 
 toRawRo :: [(PortName, KindOr (Term Chk Noun))] -> [TypeRowElem (KindOr RawVType)]
 toRawRo = fmap (\(p, bty) -> Named p (second toRaw bty))

--- a/brat/examples/fanout.brat
+++ b/brat/examples/fanout.brat
@@ -22,3 +22,9 @@ ext "" f :: { Vec(Qubit, 2) -o Bit }
 
 g(Qubit, Qubit) -o Bit
 g = [\/]; f
+
+poly(X :: *) -> { Vec(X, 3) -> X, X, X }
+poly(_) = { [/\] }
+
+poly2(X :: $) -> { X, X, X -o Vec(X, 3) }
+poly2(_) = { [\/] }

--- a/brat/examples/fanout.brat
+++ b/brat/examples/fanout.brat
@@ -17,3 +17,8 @@ swap_vec(qs) = [\/](swap(Qubit, Qubit)([/\](qs)))
 
 pack_mid(Nat, Nat, Nat, Nat) -> Nat, Vec(Nat, 2), Nat
 pack_mid = { (x=>x), [\/], .. }
+
+ext "" f :: { Vec(Qubit, 2) -o Bit }
+
+g(Qubit, Qubit) -o Bit
+g = [\/]; f

--- a/brat/examples/fanout.brat
+++ b/brat/examples/fanout.brat
@@ -14,3 +14,6 @@ as_fn = [\/](fanout([1,2,3]))
 
 swap_vec(Vec(Qubit, 2)) -o Vec(Qubit, 2)
 swap_vec(qs) = [\/](swap(Qubit, Qubit)([/\](qs)))
+
+pack_mid(Nat, Nat, Nat, Nat) -> Nat, Vec(Nat, 2), Nat
+pack_mid = { (x=>x), [\/], .. }

--- a/brat/examples/fanout.brat
+++ b/brat/examples/fanout.brat
@@ -1,0 +1,10 @@
+open import lib.kernel (CX)
+
+fanout(Vec(Nat, 3)) -> Nat, Nat, Nat
+fanout = { [/\] }
+
+swap(X :: $, Y :: $) -> { X, Y -o Y, X }
+swap(_, _) = { x, y => y, x }
+
+test(Vec(Qubit, 2)) -o Vec(Qubit, 2)
+test = { [/\]; CX; [\/] }

--- a/brat/examples/fanout.brat
+++ b/brat/examples/fanout.brat
@@ -8,3 +8,9 @@ swap(_, _) = { x, y => y, x }
 
 test(Vec(Qubit, 2)) -o Vec(Qubit, 2)
 test = { [/\]; CX; [\/] }
+
+as_fn :: Vec(Nat, 3)
+as_fn = [\/](fanout([1,2,3]))
+
+swap_vec(Vec(Qubit, 2)) -o Vec(Qubit, 2)
+swap_vec(qs) = [\/](swap(Qubit, Qubit)([/\](qs)))

--- a/brat/test/Test/Compile/Hugr.hs
+++ b/brat/test/Test/Compile/Hugr.hs
@@ -57,6 +57,7 @@ nonCompilingExamples = (expectedCheckingFails ++ expectedParsingFails ++
   ,"qft"
   ,"test"
   ,"vector"
+  ,"fanout" -- Contains Selectors
   -- Conjecture: These examples don't compile because number patterns in type
   -- signatures causes `kindCheck` to call `abstract`, creating "Selector"
   -- nodes, which we don't attempt to compile because we want to get rid of them

--- a/brat/test/golden/error/fanin-diff-types.brat
+++ b/brat/test/golden/error/fanin-diff-types.brat
@@ -1,0 +1,2 @@
+f(Qubit, Bit) -o Vec(Qubit, 2)
+f = { [\/] }

--- a/brat/test/golden/error/fanin-diff-types.brat.golden
+++ b/brat/test/golden/error/fanin-diff-types.brat.golden
@@ -1,0 +1,9 @@
+Error in test/golden/error/fanin-diff-types.brat@FC {start = Pos {line = 2, col = 5}, end = Pos {line = 2, col = 13}}:
+f = { [\/] }
+    ^^^^^^^^
+
+  Type mismatch when checking [\/]
+Expected: Qubit
+But got:  Bit
+
+

--- a/brat/test/golden/error/fanin-dynamic-length.brat
+++ b/brat/test/golden/error/fanin-dynamic-length.brat
@@ -1,0 +1,2 @@
+f(n :: #) -> { Qubit, Qubit -o Vec(Qubit, n) }
+f(n) = { [\/] }

--- a/brat/test/golden/error/fanin-dynamic-length.brat.golden
+++ b/brat/test/golden/error/fanin-dynamic-length.brat.golden
@@ -1,0 +1,6 @@
+Error in test/golden/error/fanin-dynamic-length.brat@FC {start = Pos {line = 2, col = 8}, end = Pos {line = 2, col = 16}}:
+f(n) = { [\/] }
+       ^^^^^^^^
+
+  Type error: Can't fanout a Vec with non-constant length: VPar Ex checking_check_defs_1_f_f.box_2_lambda_fake_source 0
+

--- a/brat/test/golden/error/fanin-list.brat
+++ b/brat/test/golden/error/fanin-list.brat
@@ -1,0 +1,2 @@
+f(Bool, Bool) -> List(Bool
+f = { [\/] }

--- a/brat/test/golden/error/fanin-list.brat
+++ b/brat/test/golden/error/fanin-list.brat
@@ -1,2 +1,2 @@
-f(Bool, Bool) -> List(Bool
+f(Bool, Bool) -> List(Bool)
 f = { [\/] }

--- a/brat/test/golden/error/fanin-list.brat.golden
+++ b/brat/test/golden/error/fanin-list.brat.golden
@@ -1,0 +1,6 @@
+Error in test/golden/error/fanin-list.brat@FC {start = Pos {line = 2, col = 5}, end = Pos {line = 2, col = 13}}:
+f = { [\/] }
+    ^^^^^^^^
+
+  Type error: Fanin ([\/]) only applies to Vec
+

--- a/brat/test/golden/error/fanin-not-enough-overs.brat
+++ b/brat/test/golden/error/fanin-not-enough-overs.brat
@@ -1,0 +1,2 @@
+f(Nat, Nat) -> Vec(Nat, 3)
+f = { [\/] }

--- a/brat/test/golden/error/fanin-not-enough-overs.brat.golden
+++ b/brat/test/golden/error/fanin-not-enough-overs.brat.golden
@@ -1,0 +1,6 @@
+Error in test/golden/error/fanin-not-enough-overs.brat@FC {start = Pos {line = 2, col = 5}, end = Pos {line = 2, col = 13}}:
+f = { [\/] }
+    ^^^^^^^^
+
+  Type error: Not enough inputs to make a vector of size 3
+

--- a/brat/test/golden/error/fanin-too-many-overs.brat
+++ b/brat/test/golden/error/fanin-too-many-overs.brat
@@ -1,0 +1,2 @@
+f(x :: Nat, y :: Nat, z :: Nat) -> Vec(Nat, 2)
+f = { [\/] }

--- a/brat/test/golden/error/fanin-too-many-overs.brat.golden
+++ b/brat/test/golden/error/fanin-too-many-overs.brat.golden
@@ -2,6 +2,5 @@ Error in test/golden/error/fanin-too-many-overs.brat@FC {start = Pos {line = 2, 
 f = { [\/] }
     ^^^^^^^^
 
-  Internal error: Expected empty thunk leftovers, got:
-  (z :: Nat)
+  Expected function to address all inputs, but (z :: Nat) wasn't used
 

--- a/brat/test/golden/error/fanin-too-many-overs.brat.golden
+++ b/brat/test/golden/error/fanin-too-many-overs.brat.golden
@@ -1,0 +1,7 @@
+Error in test/golden/error/fanin-too-many-overs.brat@FC {start = Pos {line = 2, col = 5}, end = Pos {line = 2, col = 13}}:
+f = { [\/] }
+    ^^^^^^^^
+
+  Internal error: Expected empty thunk leftovers, got:
+  (z :: Nat)
+

--- a/brat/test/golden/error/fanout-diff-types.brat
+++ b/brat/test/golden/error/fanout-diff-types.brat
@@ -1,0 +1,2 @@
+f(Vec(Qubit, 2)) -o Qubit, Bit
+f = { [/\] }

--- a/brat/test/golden/error/fanout-diff-types.brat.golden
+++ b/brat/test/golden/error/fanout-diff-types.brat.golden
@@ -1,0 +1,9 @@
+Error in test/golden/error/fanout-diff-types.brat@FC {start = Pos {line = 2, col = 5}, end = Pos {line = 2, col = 13}}:
+f = { [/\] }
+    ^^^^^^^^
+
+  Type mismatch when checking [/\]
+Expected: (b1 :: Bit)
+But got:  (head :: Qubit)
+
+

--- a/brat/test/golden/error/fanout-dynamic-length.brat
+++ b/brat/test/golden/error/fanout-dynamic-length.brat
@@ -1,0 +1,2 @@
+f(n :: #, Vec(Qubit, n)) -> { Qubit, Qubit }
+f(n) = { [/\] }

--- a/brat/test/golden/error/fanout-dynamic-length.brat
+++ b/brat/test/golden/error/fanout-dynamic-length.brat
@@ -1,2 +1,2 @@
-f(n :: #, Vec(Qubit, n)) -> { Qubit, Qubit }
+f(n :: #) -> { Vec(Qubit, n) -o Qubit, Qubit }
 f(n) = { [/\] }

--- a/brat/test/golden/error/fanout-dynamic-length.brat.golden
+++ b/brat/test/golden/error/fanout-dynamic-length.brat.golden
@@ -1,0 +1,6 @@
+Error in test/golden/error/fanout-dynamic-length.brat@FC {start = Pos {line = 2, col = 8}, end = Pos {line = 2, col = 16}}:
+f(n) = { [/\] }
+       ^^^^^^^^
+
+  Type error: Can't fanout a Vec with non-constant length: VPar Ex checking_check_defs_1_f_f.box_2_lambda_fake_source 0
+

--- a/brat/test/golden/error/fanout-list.brat
+++ b/brat/test/golden/error/fanout-list.brat
@@ -1,0 +1,2 @@
+f(List(Bool)) -> Bool, Bool
+f = { [/\] }

--- a/brat/test/golden/error/fanout-list.brat.golden
+++ b/brat/test/golden/error/fanout-list.brat.golden
@@ -1,0 +1,6 @@
+Error in test/golden/error/fanout-list.brat@FC {start = Pos {line = 2, col = 5}, end = Pos {line = 2, col = 13}}:
+f = { [/\] }
+    ^^^^^^^^
+
+  Type error: Fanout ([/\]) only applies to Vec
+

--- a/brat/test/golden/error/fanout-not-enough-overs.brat
+++ b/brat/test/golden/error/fanout-not-enough-overs.brat
@@ -1,0 +1,2 @@
+f(Vec(Nat, 2) -> Nat, Nat, Nat
+f = { [/\] }

--- a/brat/test/golden/error/fanout-not-enough-overs.brat
+++ b/brat/test/golden/error/fanout-not-enough-overs.brat
@@ -1,2 +1,2 @@
-f(Vec(Nat, 2) -> Nat, Nat, Nat
+f(Vec(Nat, 2)) -> Nat, Nat, Nat
 f = { [/\] }

--- a/brat/test/golden/error/fanout-not-enough-overs.brat.golden
+++ b/brat/test/golden/error/fanout-not-enough-overs.brat.golden
@@ -2,6 +2,5 @@ Error in test/golden/error/fanout-not-enough-overs.brat@FC {start = Pos {line = 
 f = { [/\] }
     ^^^^^^^^
 
-  Internal error: Expected empty thunk leftunders, got:
-  (c1 :: Nat)
+  Expected function to return additional values of type: (c1 :: Nat)
 

--- a/brat/test/golden/error/fanout-not-enough-overs.brat.golden
+++ b/brat/test/golden/error/fanout-not-enough-overs.brat.golden
@@ -1,0 +1,7 @@
+Error in test/golden/error/fanout-not-enough-overs.brat@FC {start = Pos {line = 2, col = 5}, end = Pos {line = 2, col = 13}}:
+f = { [/\] }
+    ^^^^^^^^
+
+  Internal error: Expected empty thunk leftunders, got:
+  (c1 :: Nat)
+

--- a/brat/test/golden/error/fanout-too-many-overs.brat
+++ b/brat/test/golden/error/fanout-too-many-overs.brat
@@ -1,0 +1,2 @@
+f(Vec(Nat, 3)) -> Nat, Nat
+f = { [/\] }

--- a/brat/test/golden/error/fanout-too-many-overs.brat.golden
+++ b/brat/test/golden/error/fanout-too-many-overs.brat.golden
@@ -1,0 +1,6 @@
+Error in test/golden/error/fanout-too-many-overs.brat@FC {start = Pos {line = 2, col = 5}, end = Pos {line = 2, col = 13}}:
+f = { [/\] }
+    ^^^^^^^^
+
+  Type error: No unders but overs: (head :: Nat) for [/\]
+


### PR DESCRIPTION
[See discussion here
](https://github.com/CQCL-DEV/brat/pull/312)

I've added tests that we can use these operators as a function (i.e. `[\/](x, y, z)`) and a bunch more tests, as well as some drive-by error formatting