### PR TITLE
[refactor] combine checkInputs/Outputs and use for(M)

### DIFF
--- a/brat/Brat/Checker.hs
+++ b/brat/Brat/Checker.hs
@@ -133,15 +133,14 @@ checkIO tm@(WC fc _) exps acts wireFn errMsg = do
   let _ = ?my -- otherwise ?my is "redundant" but typechecking fails without it
   let (rows, rest) = extractSuffixes exps acts
   localFC fc $ forM rows $ \(e:|exps, a:|acts) ->
-      wrapError (addRowContext (e:exps) (a:acts)) $ wireFn e a
+      wrapError (addRowContext (showRow $ e:exps) (showRow $ a:acts)) $ wireFn e a
   case rest of
     Left rest -> pure rest
     Right (u:|unfilled) -> typeErr $ errMsg ++ showRow (u:unfilled) ++ " for " ++ show tm
  where
-  addRowContext :: [(NamedPort exp, BinderType m)] -> [(NamedPort act, BinderType m)]
-              -> Error -> Error
-  addRowContext exps acts = \case
-    (Err fc (TypeMismatch tm _ _)) -> Err fc $ TypeMismatch tm (showRow exps) (showRow acts)
+  addRowContext :: String -> String -> Error -> Error
+  addRowContext exp act = \case
+    (Err fc (TypeMismatch tm _ _)) -> Err fc $ TypeMismatch tm exp act
     e -> e
   extractSuffixes :: [a] -> [b] -> ([(NonEmpty a, NonEmpty b)], Either [a] (NonEmpty b))
   extractSuffixes as [] = ([], Left as)

--- a/brat/Brat/Checker.hs
+++ b/brat/Brat/Checker.hs
@@ -122,44 +122,40 @@ checkWire Kerny (WC fc tm) outputs (dangling, ot) (hungry, ut) = localFC fc $ do
     else typeEq (show tm) (Dollar []) ut ot
   wire (dangling, ot, hungry)
 
-checkInputs :: (CheckConstraints m KVerb, ?my :: Modey m)
+checkInputs :: forall m d . (CheckConstraints m KVerb, ?my :: Modey m)
             => WC (Term d KVerb)
             -> [(Src, BinderType m)] -- Expected
             -> [(Tgt, BinderType m)] -- Actual
             -> Checking [(Src, BinderType m)]
 checkInputs _ overs [] = pure overs
 checkInputs tm@(WC fc _) (o:overs) (u:unders) = localFC fc $ do
-  wrapError (addRowContext ?my (o:overs) (u:unders)) $ checkWire ?my tm False o u
+  wrapError (addRowContext (o:overs) (u:unders)) $ checkWire ?my tm False o u
   checkInputs tm overs unders
  where
-  addRowContext :: Show (BinderType m)
-              => Modey m
-              -> [(Src, BinderType m)] -- Expected
+  addRowContext :: [(Src, BinderType m)] -- Expected
               -> [(Tgt, BinderType m)] -- Actual
               -> Error -> Error
-  addRowContext _ as bs (Err fc (TypeMismatch tm _ _))
+  addRowContext as bs (Err fc (TypeMismatch tm _ _))
    = Err fc $ TypeMismatch tm (showRow as) (showRow bs)
-  addRowContext _ _ _ e = e
+  addRowContext _ _ e = e
 checkInputs tm [] unders = typeErr $ "No overs but unders: " ++ showRow unders ++ " for " ++ show tm
 
-checkOutputs :: (CheckConstraints m k, ?my :: Modey m)
+checkOutputs :: forall m k . (CheckConstraints m k, ?my :: Modey m)
              => WC (Term Syn k)
              -> [(Tgt, BinderType m)] -- Expected
              -> [(Src, BinderType m)] -- Actual
              -> Checking [(Tgt, BinderType m)]
 checkOutputs _ unders [] = pure unders
 checkOutputs tm@(WC fc _) (u:unders) (o:overs) = localFC fc $ do
-  wrapError (addRowContext ?my (u:unders) (o:overs)) $ checkWire ?my tm True o u
+  wrapError (addRowContext (u:unders) (o:overs)) $ checkWire ?my tm True o u
   checkOutputs tm unders overs
  where
-  addRowContext :: Show (BinderType m)
-              => Modey m
-              -> [(Tgt, BinderType m)] -- Expected
+  addRowContext :: [(Tgt, BinderType m)] -- Expected
               -> [(Src, BinderType m)] -- Actual
               -> Error -> Error
-  addRowContext _ as bs (Err fc (TypeMismatch tm _ _))
+  addRowContext as bs (Err fc (TypeMismatch tm _ _))
    = Err fc $ TypeMismatch tm (showRow as) (showRow bs)
-  addRowContext _ _ _ e = e
+  addRowContext _ _ e = e
 checkOutputs tm [] overs = typeErr $ "No unders but overs: " ++ showRow overs ++ " for " ++ show tm
 
 checkThunk :: (CheckConstraints m UVerb, EvMode m)


### PR DESCRIPTION
There were two goals here:
* combine the common parts of checkInputs/Outputs, that is, they are the same apart from flipping of Src/Tgt (with `Bool` flag to `checkWire`) and the error message
* Get a list of Src+Tgt pairs, and `forM` over them - this should make it nice and easy to use `Fork` in #41

Felt I jumped through a few hoops to preserve behaviour, but maybe that's worth it, specifically I liked doing the do-the-wires-match-types *before* the "is there anything leftover" check.

Individual commits should all compile if you want to look at some intermediates (these may be plausible endpoints)