### PR TITLE
tests: pass test if files have holes; don't write out file if checking fails

### DIFF
--- a/brat/Brat/Compiler.hs
+++ b/brat/Brat/Compiler.hs
@@ -76,8 +76,8 @@ compileFile libDirs file = do
   env <- runExceptT $ loadFilename checkRoot libDirs file
   (venv, _, holes, defs, outerGraph) <- eitherIO env
   case holes of
-    [] -> Right <$> (evaluate $ -- turns 'error' into IO 'die'
-          compile defs newRoot outerGraph venv)
+    [] -> Right <$> (evaluate -- turns 'error' into IO 'die'
+            $ compile defs newRoot outerGraph venv)
     hs -> pure $ Left (CompilingHoles hs)
 
 compileAndPrintFile :: [FilePath] -> String -> IO ()

--- a/brat/Brat/Error.hs
+++ b/brat/Brat/Error.hs
@@ -78,8 +78,6 @@ data ErrorMsg
  | UnreachableBranch
  | UnrecognisedTypeCon String
  | WrongModeForType String
- -- TODO: Add file context here
- | CompilingHoles [String]
  -- For thunks which don't address enough inputs, or produce enough outputs.
  -- The argument is the row of unused connectors
  | ThunkLeftOvers String
@@ -165,9 +163,6 @@ instance Show ErrorMsg where
   -- TODO: Make all of these use existing errors
   show (UnificationError str) = "Unification error: " ++ str
   show UnreachableBranch = "Branch cannot be reached"
-  show (CompilingHoles hs) = unlines ("Can't compile file with remaining holes": indent hs)
-   where
-    indent = fmap ("  " ++)
   show (ThunkLeftOvers overs) = "Expected function to address all inputs, but " ++ overs ++ " wasn't used"
   show (ThunkLeftUnders unders) = "Expected function to return additional values of type: " ++ unders
 

--- a/brat/test/Test/Compile/Hugr.hs
+++ b/brat/test/Test/Compile/Hugr.hs
@@ -65,9 +65,7 @@ nonCompilingExamples = (expectedCheckingFails ++ expectedParsingFails ++
 compileToOutput :: FilePath -> TestTree
 compileToOutput file = testCase (show file) $ compileFile [] file >>= \case
     Right bs -> do
-      -- for non-compiling examples we end up writing out an empty file so that's invalid too
-      let isValid = not (file `elem` nonCompilingExamples || file `elem` invalidExamples)
-      let outputExt = if isValid  then "json" else "json.invalid"
+      let outputExt = if file `elem` invalidExamples then "json.invalid" else "json"
       let outFile = outputDir </> replaceExtension (takeFileName file) outputExt
       BS.writeFile outFile bs
     Left (CompilingHoles _) -> pure () -- pass, don't write out anything

--- a/brat/test/Test/Compile/Hugr.hs
+++ b/brat/test/Test/Compile/Hugr.hs
@@ -53,12 +53,13 @@ nonCompilingExamples = (expectedCheckingFails ++ expectedParsingFails ++
   ])
 
 compileToOutput :: FilePath -> TestTree
-compileToOutput file = testCase (show file) $ compileFile [] file >>= \case
+compileToOutput file = testCaseInfo (show file) $ compileFile [] file >>= \case
     Right bs -> do
       let outputExt = if file `elem` invalidExamples then "json.invalid" else "json"
       let outFile = outputDir </> replaceExtension (takeFileName file) outputExt
       BS.writeFile outFile bs
-    Left (CompilingHoles _) -> pure () -- pass, don't write out anything
+      pure $ "Written to " ++ outFile
+    Left (CompilingHoles _) -> pure "Skipped as contains holes"
 
 setupCompilationTests :: IO TestTree
 setupCompilationTests = do

--- a/brat/test/Test/Compile/Hugr.hs
+++ b/brat/test/Test/Compile/Hugr.hs
@@ -3,8 +3,7 @@ module Test.Compile.Hugr where
 import Brat.Checker (run)
 import Brat.Checker.Monad (Checking)
 import Brat.Checker.Types (TypedHole)
-import Brat.Compiler (compileFile)
-import Brat.Error (Error)
+import Brat.Compiler (compileFile, CompilingHoles(..))
 import Brat.Graph (Graph)
 import Brat.Naming (root)
 import Test.Checking (expectedCheckingFails)
@@ -82,7 +81,7 @@ compileToOutput file = testCase (show file) $ do
   let outFile = outputDir </> replaceExtension (takeFileName file) outputExt
   compileFile [] file >>= \case
     Right bs -> BS.writeFile outFile bs
-    Left err -> assertFailure err
+    Left err -> assertFailure (show err)
 
 setupCompilationTests :: IO TestTree
 setupCompilationTests = do

--- a/brat/test/Test/Compile/Hugr.hs
+++ b/brat/test/Test/Compile/Hugr.hs
@@ -58,7 +58,7 @@ compileToOutput file = testCaseInfo (show file) $ compileFile [] file >>= \case
       let outputExt = if file `elem` invalidExamples then "json.invalid" else "json"
       let outFile = outputDir </> replaceExtension (takeFileName file) outputExt
       BS.writeFile outFile bs
-      pure $ "Written to " ++ outFile
+      pure $ "Written to " ++ outFile ++ " pending validation"
     Left (CompilingHoles _) -> pure "Skipped as contains holes"
 
 setupCompilationTests :: IO TestTree

--- a/brat/test/Test/Compile/Hugr.hs
+++ b/brat/test/Test/Compile/Hugr.hs
@@ -27,7 +27,6 @@ invalidExamples = map ((++ ".brat") . ("examples" </>))
 
 -- examples that we expect not to compile.
 -- Note this does not include those with remaining holes; these are automatically skipped.
--- ()
 nonCompilingExamples = (expectedCheckingFails ++ expectedParsingFails ++
   map ((++ ".brat") . ("examples" </>))
   ["fzbz"


### PR DESCRIPTION
* First, refactor: move `CompilingHoles` out of `Error`; it is only used in one place, where there is no other possible `Error`. Make `CompileFile` return `CompilingHoles` rather than `String`.
* Second, pass compilation rather than (expected-)fail if there are holes. This does seem a bit silent, so other options (all a bit harder):
    * Maintain a *separate* list of files with holes that we expect to fail in this way
    * Do checking first, and only generate a compilation test for files that check without any holes. That way, these compilation tests disappear from the list of run tests, rather than appearing to pass.
* Third, fix the weird bug that files that `error`d in compilation, still returned an empty bytestring. This is not what I'd have expected from `error` but the fix seems to be to use `evaluate` from `Control.Exception` getting us an `IO ByteString` that `die`s if there was an `error`.