### PR TITLE
Tests: error on unused imports

### DIFF
--- a/brat/brat.cabal
+++ b/brat/brat.cabal
@@ -152,6 +152,8 @@ test-suite tests
   import:              ghc-perf, haskell
   type:                exitcode-stdio-1.0
   default-language:    GHC2021
+  ghc-options:
+    -Werror=unused-imports
   hs-source-dirs:      test
   main-is:             Main.hs
   other-modules:       Test.Abstractor,

--- a/brat/test/Test/Abstractor.hs
+++ b/brat/test/Test/Abstractor.hs
@@ -8,7 +8,6 @@ import Test.Tasty.QuickCheck
 
 import Brat.Syntax.Abstractor
 import Brat.Syntax.Simple
-import Brat.UserName
 import Util
 
 abstractor :: Int -> Gen Abstractor

--- a/brat/test/Test/Checking.hs
+++ b/brat/test/Test/Checking.hs
@@ -1,19 +1,11 @@
 module Test.Checking (getCheckingTests, expectedCheckingFails) where
 
-import Brat.Checker (run)
-import Brat.Checker.Monad (Checking)
-import Brat.Checker.Types (TypedHole)
-import Brat.Error (Error)
-import Brat.Graph (Graph)
-import Brat.Naming (root)
 import Test.Parsing (expectedParsingFails, expectFailForPaths)
 import Test.Util (parseAndCheck)
 
 import System.FilePath
 import Test.Tasty
-import Test.Tasty.HUnit
 import Test.Tasty.Silver
-import Test.Tasty.ExpectedFailure
 
 expectedCheckingFails = map ("examples" </>) ["nested-abstractors.brat"
                                              ,"karlheinz_alias.brat"

--- a/brat/test/Test/Compile/Hugr.hs
+++ b/brat/test/Test/Compile/Hugr.hs
@@ -1,25 +1,15 @@
 module Test.Compile.Hugr where
 
-import Brat.Checker (run)
-import Brat.Checker.Monad (Checking)
-import Brat.Checker.Types (TypedHole)
 import Brat.Compiler (compileFile)
-import Brat.Error (Error)
-import Brat.Graph (Graph)
-import Brat.Naming (root)
 import Test.Checking (expectedCheckingFails)
 import Test.Parsing (expectedParsingFails, expectFailForPaths)
-import Test.Util (parseAndCheck)
 
 import qualified Data.ByteString.Lazy as BS
-import Data.List (partition)
-import Data.Traversable (for)
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.Silver
-import Test.Tasty.ExpectedFailure
 
 prefix = "test/compilation"
 examplesPrefix = "examples"

--- a/brat/test/Test/Elaboration.hs
+++ b/brat/test/Test/Elaboration.hs
@@ -12,7 +12,6 @@ import Brat.FC
 import Data.Functor ((<&>))
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.PartialOrd as PO
-import qualified Data.Set as S
 import Test.Tasty
 import Test.Tasty.HUnit
 

--- a/brat/test/Test/Failure.hs
+++ b/brat/test/Test/Failure.hs
@@ -3,7 +3,6 @@ module Test.Failure (getFailureTests) where
 import Test.Tasty
 import Test.Tasty.Silver
 import System.Exit (ExitCode(..))
-import Control.Monad (unless)
 import Control.Exception
 import System.FilePath
 import System.IO

--- a/brat/test/Test/Graph.hs
+++ b/brat/test/Test/Graph.hs
@@ -8,7 +8,7 @@ import Control.Monad.Except (runExceptT)
 import Data.List (sortOn)
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Text (pack)
-import System.FilePath ((<.>), FilePath, takeBaseName)
+import System.FilePath ((<.>), takeBaseName)
 import Test.Tasty
 import Test.Tasty.HUnit (assertFailure)
 import Test.Tasty.Silver

--- a/brat/test/Test/Parsing.hs
+++ b/brat/test/Test/Parsing.hs
@@ -1,9 +1,7 @@
 module Test.Parsing (getParsingTests, expectedParsingFails, expectFailForPaths) where
 
 import Brat.Load
-import Brat.Parser
 
-import Control.Monad.Except
 import System.FilePath
 import Test.Tasty
 import Test.Tasty.HUnit

--- a/brat/test/Test/Search.hs
+++ b/brat/test/Test/Search.hs
@@ -3,24 +3,18 @@
 module Test.Search {- (searchTests) -} where
 
 import Brat.Checker (check)
-import Brat.Checker.Types (Modey(..))
 import Brat.FC
 import Brat.Naming
 import Brat.Search (vsearch)
 import Brat.Syntax.Common
-import Brat.Syntax.Core
-import Brat.Syntax.Simple (SimpleTerm(..))
 import Hasochism (N(..))
 import Util (names)
 import Test.Util (runEmpty)
 
-import Data.Either (isRight)
 import Data.Functor ((<&>))
 import Test.QuickCheck
 import Test.Tasty.QuickCheck (testProperty)
-import Test.Tasty
 import Brat.Syntax.Value
-import Bwd
 
 
 -- Bounds for row lengths

--- a/brat/test/Test/Substitution.hs
+++ b/brat/test/Test/Substitution.hs
@@ -1,5 +1,9 @@
 module Test.Substitution where
 
+import Test.Tasty
+
+{-
+-- TODO: update to value scopes syntax
 import Brat.Checker.Monad
 import Brat.Checker.Types
 import Brat.Error
@@ -15,11 +19,7 @@ import Hasochism
 import Test.Util (runEmpty)
 
 import Data.Bifunctor
-import Test.Tasty
 import Test.Tasty.HUnit
-
-{-
--- TODO: update to value scopes syntax
 
 node = fst (fresh "" root)
 

--- a/brat/test/Test/Syntax/Let.hs
+++ b/brat/test/Test/Syntax/Let.hs
@@ -5,8 +5,6 @@ module Test.Syntax.Let where
 import Brat.Error (showError)
 import Brat.Checker
 import Brat.FC
-import Brat.Load
-import Brat.Naming
 import Brat.Syntax.Common
 import Brat.Syntax.Core
 import Brat.Syntax.Simple
@@ -15,7 +13,6 @@ import Brat.UserName
 import Test.Util (runEmpty)
 
 import Data.String
-import Test.Tasty
 import Test.Tasty.HUnit
 
 instance IsString UserName where

--- a/brat/test/Test/TypeArith.hs
+++ b/brat/test/Test/TypeArith.hs
@@ -2,13 +2,11 @@
 module Test.TypeArith where
 
 import Brat.Checker.Helpers (runArith)
-import Brat.FC
 import Brat.Naming (Name(..))
-import Brat.Syntax.Common (ArithOp(..), TypeKind(Nat))
+import Brat.Syntax.Common (ArithOp(..))
 import Brat.Syntax.Port
-import Brat.Syntax.Simple (SimpleTerm(..))
 import Brat.Syntax.Value
-import Hasochism (N(..), Ny(..), Some(..), (:*)(..))
+import Hasochism (N(..))
 
 import Data.List (sort)
 import Test.Tasty

--- a/brat/test/Test/Util.hs
+++ b/brat/test/Test/Util.hs
@@ -7,10 +7,6 @@ import Brat.Error
 import Brat.FC
 import Brat.Load
 import Brat.Naming
-import Brat.Syntax.Common (CType'(..), TypeKind)
-import Brat.Syntax.Port
-import Brat.Syntax.Value
-import Bwd
 
 import Control.Monad.Except
 import Test.Tasty


### PR DESCRIPTION
Well, it can be a pain keeping things like import lists up-to-date, but OTOH it also makes refactoring more of a pain if they aren't, and I was trying to do a refactoring, so....

The number of imports deleted here is indicative of *something*, I think ;-), and this was the easiest way to find them.

We could turn more warnings on, but that'll be a big PR if we do them all, so proceeding in stages...