### PR TITLE
chore(ci): Try harder to cache stack deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  GHC_VERSION: 9.6.4
+  CABAL_VERSION: 3.4
+
 jobs:
   build:
 
@@ -20,8 +24,8 @@ jobs:
     - uses: actions/checkout@v4
     - uses: haskell-actions/setup@v2
       with:
-        ghc-version: '9.6.4'
-        cabal-version: '3.4'
+        ghc-version: ${{ env.GHC_VERSION }}
+        cabal-version: ${{ env.CABAL_VERSION }}
         enable-stack: true
 
     - uses: actions/cache@v4
@@ -38,7 +42,9 @@ jobs:
         key: ${{ runner.os }}-stack-${{ hashFiles('brat/stack.yaml',
                                                   'hugr_validator/Cargo.toml',
                                                   'hugr_extension/Cargo.toml',
-                                                  '${{ steps.setup.outputs.ghc-version }}') }}
+                                                  '${{ env.GHC_VERSION }}',
+                                                  '${{ env.CABAL_VERSION }}'
+                                                  )}}
         save-always: true
 
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,8 @@ jobs:
         # best effort for cache: tie it to Stack resolver and package config
         key: ${{ runner.os }}-stack-${{ hashFiles('brat/stack.yaml',
                                                   'hugr_validator/Cargo.toml',
-                                                  'hugr_extension/Cargo.toml') }}
+                                                  'hugr_extension/Cargo.toml'
+                                                  ${{ steps.setup.outputs.ghc-version }}) }}
         restore-keys: |
           ${{ runner.os }}-stack
         save-always: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
         key: ${{ runner.os }}-stack-${{ hashFiles('brat/stack.yaml',
                                                   'hugr_validator/Cargo.toml',
                                                   'hugr_extension/Cargo.toml',
-                                                  '${{ env.GHC_VERSION }}',
-                                                  '${{ env.CABAL_VERSION }}'
+                                                  '${{ steps.setup.outputs.ghc-exe }}',
+                                                  '${{ steps.setup.outputs.cabal-exe }}'
                                                   )}}
         save-always: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         path: |
           ~/.stack
           .stack-work
+          */.stack-work
           ~/.cargo
         # best effort for cache: tie it to Stack resolver and package config
         key: ${{ runner.os }}-stack-${{ hashFiles('brat/stack.yaml',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         working-directory: brat/
 
     steps:
+    # from: https://raehik.github.io/2021/03/01/caching-stack-and-cabal-haskell-builds-on-github-actions.html
     - uses: actions/checkout@v4
     - uses: haskell-actions/setup@v2
       with:
@@ -23,7 +24,6 @@ jobs:
         cabal-version: '3.4'
         enable-stack: true
 
-    # from: https://raehik.github.io/2021/03/01/caching-stack-and-cabal-haskell-builds-on-github-actions.html
     - uses: actions/cache@v4
       with:
         path: |
@@ -31,6 +31,9 @@ jobs:
           .stack-work
           */.stack-work
           ~/.cargo
+          ${{ steps.setup.outputs.ghc-path }}
+          ${{ steps.setup.outputs.cabal-path }}
+          ${{ steps.setup.outputs.stack-path }}
         # best effort for cache: tie it to Stack resolver and package config
         key: ${{ runner.os }}-stack-${{ hashFiles('brat/stack.yaml',
                                                   'hugr_validator/Cargo.toml',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,8 @@ jobs:
         # best effort for cache: tie it to Stack resolver and package config
         key: ${{ runner.os }}-stack-${{ hashFiles('brat/stack.yaml',
                                                   'hugr_validator/Cargo.toml',
-                                                  'hugr_extension/Cargo.toml',
-                                                  '${{ steps.setup.outputs.ghc-exe }}',
-                                                  '${{ steps.setup.outputs.cabal-exe }}'
-                                                  )}}
+                                                  'hugr_extension/Cargo.toml'
+                                                  )}}-GHC-${{ env.GHC_VERSION }}
         save-always: true
 
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,8 @@ jobs:
         # best effort for cache: tie it to Stack resolver and package config
         key: ${{ runner.os }}-stack-${{ hashFiles('brat/stack.yaml',
                                                   'hugr_validator/Cargo.toml',
-                                                  'hugr_extension/Cargo.toml'
-                                                  ${{ steps.setup.outputs.ghc-version }}) }}
-        restore-keys: |
-          ${{ runner.os }}-stack
+                                                  'hugr_extension/Cargo.toml',
+                                                  '${{ steps.setup.outputs.ghc-version }}') }}
         save-always: true
 
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,30 +20,35 @@ jobs:
         working-directory: brat/
 
     steps:
-    # from: https://raehik.github.io/2021/03/01/caching-stack-and-cabal-haskell-builds-on-github-actions.html
     - uses: actions/checkout@v4
-    - uses: haskell-actions/setup@v2
-      with:
-        ghc-version: ${{ env.GHC_VERSION }}
-        cabal-version: ${{ env.CABAL_VERSION }}
-        enable-stack: true
 
-    - uses: actions/cache@v4
+    # From: https://raehik.github.io/2021/03/01/caching-stack-and-cabal-haskell-builds-on-github-actions.html
+    - name: cache
+      uses: actions/cache@v4
       with:
         path: |
           ~/.stack
           .stack-work
           */.stack-work
           ~/.cargo
-          ${{ steps.setup.outputs.ghc-path }}
-          ${{ steps.setup.outputs.cabal-path }}
-          ${{ steps.setup.outputs.stack-path }}
+          # From: https://github.com/commercialhaskell/stack/issues/5754#issuecomment-1696156869
+          ~/.ghcup/bin/*
+          ~/.ghcup/cache/*
+          ~/.ghcup/config.yaml
+          ~/.ghcup/ghc/${{ env.GHC_VERSION }}
         # best effort for cache: tie it to Stack resolver and package config
         key: ${{ runner.os }}-stack-${{ hashFiles('brat/stack.yaml',
                                                   'hugr_validator/Cargo.toml',
                                                   'hugr_extension/Cargo.toml'
                                                   )}}-GHC-${{ env.GHC_VERSION }}
         save-always: true
+
+    - uses: haskell-actions/setup@v2
+      if: steps.cache.outputs.cache-hit != 'true'
+      with:
+        ghc-version: ${{ env.GHC_VERSION }}
+        cabal-version: ${{ env.CABAL_VERSION }}
+        enable-stack: true
 
     - name: Install dependencies
       run: stack build --only-dependencies

--- a/brat/Brat/Checker.hs
+++ b/brat/Brat/Checker.hs
@@ -189,7 +189,7 @@ check :: (CheckConstraints m k
       -> ChkConnectors m d k
       -> Checking (SynConnectors m d k
                   ,ChkConnectors m d k)
-check (WC fc tm) conn = let x = fc in localFC x (check' tm conn)
+check (WC fc tm) conn = localFC fc (check' tm conn)
 
 check' :: forall m d k
         . (CheckConstraints m k

--- a/brat/Brat/Checker.hs
+++ b/brat/Brat/Checker.hs
@@ -189,7 +189,7 @@ check :: (CheckConstraints m k
       -> ChkConnectors m d k
       -> Checking (SynConnectors m d k
                   ,ChkConnectors m d k)
-check (WC fc tm) conn = localFC fc (check' tm conn)
+check (WC fc tm) conn = let x = fc in localFC x (check' tm conn)
 
 check' :: forall m d k
         . (CheckConstraints m k


### PR DESCRIPTION
Cache GHC and stack dependencies. The latter I had thought we were already donig but it wasn't working!
I think because of github's namespacing, we still need to build everything fresh for each PR, but subsequent builds (as in this PR) can be (<1m)!