### PR TITLE
chore: Update compilation to target hugr v0.6.0

### DIFF
--- a/brat/Brat/Compile/Hugr.hs
+++ b/brat/Brat/Compile/Hugr.hs
@@ -198,7 +198,7 @@ registerCompiled from to = do
 
 compileConst :: NodeId -> SimpleTerm -> HugrType -> Compile NodeId
 compileConst parent tm ty = do
-  constId <- addNode "Const" (OpConst (ConstOp parent (constFromSimple tm) ty))
+  constId <- addNode "Const" (OpConst (ConstOp parent (valFromSimple tm) ty))
   loadId <- addNode "LoadConst" (OpLoadConstant (LoadConstantOp parent ty))
   addEdge (Port constId 0, Port loadId 0)
   pure loadId
@@ -523,7 +523,7 @@ compileConstDfg parent desc box_sig contents = do
   let nestedHugr = renameAndSortHugr (nodes cs) (edges cs)
   let ht = HTFunc $ PolyFuncType [] box_sig
 
-  constNode <- addNode ("ConstTemplate_" ++ desc) (OpConst (ConstOp parent (HCFunction nestedHugr) ht))
+  constNode <- addNode ("ConstTemplate_" ++ desc) (OpConst (ConstOp parent (HVFunction nestedHugr) ht))
   lcPort <- head <$> addNodeWithInputs ("LoadTemplate_" ++ desc) (OpLoadConstant (LoadConstantOp parent ht))
             [(Port constNode 0, ht)] [ht]
   pure (lcPort, res)
@@ -762,7 +762,7 @@ compilePrimTest parent (port, ty) (PrimCtorTest c tycon unpackingNode outputs) =
   pure (Port testId 0, sumOut)
 compilePrimTest parent port@(_, ty) (PrimLitTest tm) = do
   -- Make a Const node that holds the value we test against
-  constId <- addNode "LitConst" (OpConst (ConstOp parent (constFromSimple tm) ty))
+  constId <- addNode "LitConst" (OpConst (ConstOp parent (valFromSimple tm) ty))
   loadPort <- head <$> addNodeWithInputs "LitLoad" (OpLoadConstant (LoadConstantOp parent ty))
                        [(Port constId 0, ty)] [ty]
   -- Connect to a test node
@@ -790,7 +790,7 @@ undoPrimTest parent inPorts outTy (PrimCtorTest c tycon _ _) = do
            [outTy]
 undoPrimTest parent inPorts outTy (PrimLitTest tm) = do
   unless (null inPorts) $ error "Unexpected inPorts"
-  constId <- addNode "LitConst" (OpConst (ConstOp parent (constFromSimple tm) outTy))
+  constId <- addNode "LitConst" (OpConst (ConstOp parent (valFromSimple tm) outTy))
   head <$> addNodeWithInputs "LitLoad" (OpLoadConstant (LoadConstantOp parent outTy))
            [(Port constId 0, outTy)] [outTy]
 

--- a/brat/Brat/Compile/Hugr.hs
+++ b/brat/Brat/Compile/Hugr.hs
@@ -681,13 +681,8 @@ compileMatchSequence parent portTable (MatchSequence {..}) = do
     makeRowTag "DidNotMatch" parent 0 sumTy ins
 
 makeRowTag :: String -> NodeId -> Int -> SumOfRows -> [TypedPort] -> Compile [TypedPort]
-makeRowTag hint parent tag sor@(SoR sumRows) ins = assert (sumRows !! tag == (snd <$> ins)) $ do
-  wires <- case sumRows !! tag of
-    -- Tag ops which produce an empty row (i.e. what we use for bools) don't
-    -- require any inputs
-    [] -> pure []
-    _ -> addNodeWithInputs (hint ++ "_MakeTuple") (OpMakeTuple (MakeTupleOp parent (snd <$> ins))) ins [htTuple (snd <$> ins)]
-  addNodeWithInputs (hint ++ "_Tag") (OpTag (TagOp parent tag sumRows)) wires [compileSumOfRows sor]
+makeRowTag hint parent tag sor@(SoR sumRows) ins = assert (sumRows !! tag == (snd <$> ins)) $
+  addNodeWithInputs (hint ++ "_Tag") (OpTag (TagOp parent tag sumRows)) ins [compileSumOfRows sor]
 
 getSumVariants :: HugrType -> [[HugrType]]
 getSumVariants (HTSum (SU (UnitSum n))) = replicate n []

--- a/brat/Data/Hugr.hs
+++ b/brat/Data/Hugr.hs
@@ -518,6 +518,24 @@ instance ToJSON node => ToJSON (LoadConstantOp node) where
                                         ,"datatype" .= datatype
                                         ]
 
+data LoadFunctionOp node = LoadFunctionOp
+  { parent :: node
+  , func_sig :: PolyFuncType
+  , type_args :: [TypeArg]
+  , signature :: FunctionType
+  } deriving (Eq, Functor, Show)
+
+instance Eq node => Ord (LoadFunctionOp node) where
+  compare _ _ = EQ
+
+instance ToJSON node => ToJSON (LoadFunctionOp node) where
+  toJSON (LoadFunctionOp {..}) = object ["parent" .= parent
+                                        ,"op" .= ("LoadFunction" :: Text)
+                                        ,"func_sig" .= func_sig
+                                        ,"type_args" .= type_args
+                                        ,"signature" .= signature
+                                        ]
+
 data NoopOp node = NoopOp
   { parent :: node
   , ty :: HugrType
@@ -551,6 +569,7 @@ data HugrOp node
   | OpCall (CallOp node)
   | OpCallIndirect (CallIndirectOp node)
   | OpLoadConstant (LoadConstantOp node)
+  | OpLoadFunction (LoadFunctionOp node)
   | OpNoop (NoopOp node)
  deriving (Eq, Functor, Ord, Show)
 
@@ -569,6 +588,7 @@ instance ToJSON node => ToJSON (HugrOp node) where
   toJSON (OpCall op) = toJSON op
   toJSON (OpCallIndirect op) = toJSON op
   toJSON (OpLoadConstant op) = toJSON op
+  toJSON (OpLoadFunction op) = toJSON op
   toJSON (OpNoop op) = toJSON op
 
 getParent :: HugrOp node -> node
@@ -586,6 +606,7 @@ getParent (OpCustom (CustomOp { parent = parent })) = parent
 getParent (OpCall (CallOp { parent = parent })) = parent
 getParent (OpCallIndirect (CallIndirectOp { parent = parent })) = parent
 getParent (OpLoadConstant (LoadConstantOp { parent = parent })) = parent
+getParent (OpLoadFunction (LoadFunctionOp { parent = parent })) = parent
 getParent (OpNoop (NoopOp { parent = parent })) = parent
 
 data Hugr node = Hugr [HugrOp node] [(PortId node, PortId node)]

--- a/brat/Data/Hugr.hs
+++ b/brat/Data/Hugr.hs
@@ -592,9 +592,10 @@ data Hugr node = Hugr [HugrOp node] [(PortId node, PortId node)]
   deriving (Eq, Functor, Show)
 
 instance ToJSON node => ToJSON (Hugr node) where
-  toJSON (Hugr ns es) = object ["version" .= ("v0" :: Text)
+  toJSON (Hugr ns es) = object ["version" .= ("v1" :: Text)
                                ,"nodes" .= ns
                                ,"edges" .= es
+                               ,"encoder" .= ("BRAT" :: Text)
                                ]
 
 orderEdgeOffset :: Int

--- a/brat/examples/tups.brat
+++ b/brat/examples/tups.brat
@@ -1,6 +1,9 @@
 nil :: []
 nil = []
 
+single :: [Bool]
+single = [true]
+
 double :: [Bool, Int]
 double = [true, 1]
 

--- a/hugr_extension/Cargo.toml
+++ b/hugr_extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brat_extension"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [lib]

--- a/hugr_extension/Cargo.toml
+++ b/hugr_extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brat_extension"
-version = "0.3.0"
+version = "0.2.0"
 edition = "2021"
 
 [lib]

--- a/hugr_extension/Cargo.toml
+++ b/hugr_extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brat_extension"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [lib]
@@ -9,7 +9,7 @@ bench = false
 path = "src/lib.rs"
 
 [dependencies]
-hugr = "0.4.0"
+hugr = "0.6.0"
 serde = "1.0"
 serde_json = "1.0.97"
 

--- a/hugr_extension/Cargo.toml
+++ b/hugr_extension/Cargo.toml
@@ -9,7 +9,7 @@ bench = false
 path = "src/lib.rs"
 
 [dependencies]
-quantinuum-hugr = "0.2.0"
+hugr = "0.4.0"
 serde = "1.0"
 serde_json = "1.0.97"
 
@@ -19,4 +19,3 @@ lazy_static = "1.4.0"
 strum = "0.26.1"
 strum_macros = "0.26.1"
 enum-iterator = "2.0.1"
-

--- a/hugr_extension/src/ctor.rs
+++ b/hugr_extension/src/ctor.rs
@@ -1,6 +1,6 @@
 use enum_iterator::Sequence;
 use hugr::{
-    ops::OpName,
+    ops::NamedOp,
     std_extensions::{arithmetic::int_types, collections},
     types::{
         type_param::TypeParam, CustomType, FunctionType, PolyFuncType, Type, TypeArg, TypeBound,
@@ -31,7 +31,7 @@ pub enum VecCtor {
     cons,
 }
 
-impl OpName for BratCtor {
+impl NamedOp for BratCtor {
     fn name(&self) -> SmolStr {
         match self {
             BratCtor::Nat(ctor) => format_smolstr!("Nat::{}", ctor.name()),

--- a/hugr_extension/src/defs.rs
+++ b/hugr_extension/src/defs.rs
@@ -8,7 +8,7 @@ use hugr::{
         simple_op::{MakeOpDef, OpLoadError},
         OpDef, SignatureError, SignatureFromArgs, SignatureFunc,
     },
-    ops::OpName,
+    ops::NamedOp,
     std_extensions::collections::list_type,
     types::{type_param::TypeParam, FunctionType, PolyFuncType, Type, TypeArg, TypeBound},
 };
@@ -33,7 +33,7 @@ pub enum BratOpDef {
     Replicate,
 }
 
-impl OpName for BratOpDef {
+impl NamedOp for BratOpDef {
     fn name(&self) -> SmolStr {
         use BratOpDef::*;
         match self {
@@ -82,7 +82,7 @@ impl MakeOpDef for BratOpDef {
             PrimCtorTest(ctor) => {
                 let sig = ctor.signature();
                 let input = sig.body().output(); // Ctor output is input for the test
-                let output = Type::new_tuple_sum(vec![input.clone(), sig.body().input().clone()]);
+                let output = Type::new_sum(vec![input.clone(), sig.body().input().clone()]);
                 PolyFuncType::new(sig.params(), FunctionType::new(input.clone(), vec![output]))
                     .into()
             }

--- a/hugr_extension/src/lib.rs
+++ b/hugr_extension/src/lib.rs
@@ -56,7 +56,7 @@ impl MakeRegisteredOp for BratOpDef {
 mod test {
     use hugr::{
         extension::simple_op::MakeExtensionOp,
-        ops::{custom::ExtensionOp, OpName},
+        ops::{custom::ExtensionOp, NamedOp},
         types::{type_param::TypeParam, FunctionType, Type, TypeArg},
     };
 

--- a/hugr_extension/src/ops.rs
+++ b/hugr_extension/src/ops.rs
@@ -3,7 +3,7 @@ use hugr::{
         simple_op::{MakeExtensionOp, MakeOpDef, OpLoadError},
         SignatureError,
     },
-    ops::{custom::ExtensionOp, OpName, OpTrait},
+    ops::{custom::ExtensionOp, NamedOp, OpTrait},
     types::{FunctionType, TypeArg, TypeEnum, TypeRow},
 };
 use smol_str::{format_smolstr, SmolStr};
@@ -40,7 +40,7 @@ pub enum BratOp {
     Replicate(TypeArg),
 }
 
-impl OpName for BratOp {
+impl NamedOp for BratOp {
     fn name(&self) -> SmolStr {
         use BratOp::*;
         match self {
@@ -74,12 +74,12 @@ impl MakeExtensionOp for BratOp {
                     let hole_sigs: Result<Vec<_>, OpLoadError> = hole_sigs
                         .iter()
                         .map(|ty| match ty.as_type_enum() {
-                            TypeEnum::Function(f) => Ok(f.body().clone()),
+                            TypeEnum::Function(f) => Ok(*f.clone()),
                             _ => Err(SignatureError::InvalidTypeArgs.into()),
                         })
                         .collect();
                     Ok(BratOp::Substitute {
-                        func_sig: func_sig.body().clone(),
+                        func_sig: *func_sig.clone(),
                         hole_sigs: hole_sigs?,
                     })
                 }
@@ -92,7 +92,7 @@ impl MakeExtensionOp for BratOp {
                     };
                     Ok(BratOp::Partial {
                         inputs: partial_inputs.to_vec().into(),
-                        output_sig: output_sig.body().clone(),
+                        output_sig: *output_sig.clone(),
                     })
                 }
                 _ => Err(OpLoadError::InvalidArgs(SignatureError::InvalidTypeArgs)),
@@ -144,7 +144,7 @@ impl MakeExtensionOp for BratOp {
             BratOp::Panic { sig } => vec![arg_from_row(sig.input()), arg_from_row(sig.output())],
             BratOp::Ctor { args, .. } => args.clone(),
             BratOp::PrimCtorTest { args, .. } => args.clone(),
-            BratOp::Replicate(arg) => vec![arg],
+            BratOp::Replicate(arg) => vec![arg.clone()],
         }
     }
 }

--- a/hugr_validator/Cargo.toml
+++ b/hugr_validator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugr_validator"
-version = "0.3.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/hugr_validator/Cargo.toml
+++ b/hugr_validator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugr_validator"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/hugr_validator/Cargo.toml
+++ b/hugr_validator/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "hugr_validator"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]
-hugr = "0.4.0"
+hugr = "0.6.0"
 serde_json = "*"
 brat_extension = { path = "../hugr_extension" }

--- a/hugr_validator/Cargo.toml
+++ b/hugr_validator/Cargo.toml
@@ -3,9 +3,7 @@ name = "hugr_validator"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-quantinuum-hugr = "0.2.0"
+hugr = "0.4.0"
 serde_json = "*"
 brat_extension = { path = "../hugr_extension" }


### PR DESCRIPTION
Based off #51. Closes #5.
* Get rid of tupling in places where it's no longer required. We can pass around rows more freely now
* Add LoadFunction op and use it in place of LoadConst when appropriate
* Replace `HugrConst` by adding `HugrValue` and `CustomConst` which wraps values