### PR TITLE
[refactor] Common-up in checkBody

### DIFF
--- a/brat/Brat/Checker.hs
+++ b/brat/Brat/Checker.hs
@@ -710,16 +710,15 @@ checkBody :: (CheckConstraints m UVerb, EvMode m, ?my :: Modey m)
           -> CTy m Z -- Function type
           -> Checking Src
 checkBody fnName body cty = do
-  (tm, checkFn) <- case body of
-    NoLhs tm -> pure (tm, checkConnectorsUsed (fcOf tm, fcOf tm) (show tm))
+  (tm, fcs) <- case body of
+    NoLhs tm -> pure (tm, (fcOf tm, fcOf tm))
     Clauses (c :| cs) -> do
       fc <- req AskFC
-      let tm = Lambda c cs
-      pure $ (WC fc tm, checkConnectorsUsed (bimap fcOf fcOf c) (show tm))
+      pure $ (WC fc (Lambda c cs), (bimap fcOf fcOf c))
     Undefined -> err (InternalError "Checking undefined clause")
   ((src, _), _) <- makeBox (fnName ++ ".box") cty $ \conns -> do
     (((), ()), leftovers) <- check tm conns
-    checkFn conns leftovers
+    checkConnectorsUsed fcs (show tm) conns leftovers
   pure src
  where
   checkConnectorsUsed _ _ _ ([], []) = pure ()


### PR DESCRIPTION
This arose trying to merge #41 with already-on-`main` #48.

Three commits....
* the first (pure refactor) just commons up the two `makeBox` calls. This requires a slightly awkward currying of `checkConnectorsUsed` in order to preserve exact behaviour (specifically, passing in `show tm` rather than `show (WC fc tm)` in the Clauses case).
* the second changes the Clauses case to `show (WC fc tm)` rather than `show tm`, paralleling the `NoLhs` case (but with a fake FC). However this doesn't actually change the output (changing that to `"foo"` breaks tests, but this change doesn't), so seems harmless.
* The third (again, pure refactor) tidies up by inlining now-singly-called `checkConnectorsUsed`