### PR TITLE
[refactor] pull1Port: use `partition` from Data.List

### DIFF
--- a/brat/Brat/Checker/Helpers.hs
+++ b/brat/Brat/Checker/Helpers.hs
@@ -125,8 +125,6 @@ pullPorts toPort showFn (p:ports) types = do
   pull1Port p available = case partition ((== p) . toPort . fst) available of
       ([], _) -> err $ BadPortPull $ "Port not found: " ++ p ++ " in " ++ showFn available
       ([found], remaining) -> pure (found, remaining)
-      -- this is not quite a refactor: we used to show only the suffix
-      -- of 'available' beginning with the first match
       (_, _) -> err $ AmbiguousPortPull p (showFn available)
 
 ensureEmpty :: Show ty => String -> [(NamedPort e, ty)] -> Checking ()

--- a/brat/Brat/Checker/Helpers.hs
+++ b/brat/Brat/Checker/Helpers.hs
@@ -121,7 +121,7 @@ pullPorts toPort showFn (p:ports) types = do
   pull1Port :: PortName
             -> [(a, ty)]
             -> Checking ((a, ty), [(a, ty)])
-  pull1Port p [] = fail $ "Port not found: " ++ p ++ " in " ++ showFn types
+  pull1Port p [] = err $ BadPortPull $ "Port not found: " ++ p ++ " in " ++ showFn types
   pull1Port p (x@(a,_):xs)
    | p == toPort a
    = if p `elem` (toPort . fst <$> xs)

--- a/brat/Brat/Checker/Helpers.hs
+++ b/brat/Brat/Checker/Helpers.hs
@@ -39,6 +39,7 @@ import Util (log2)
 import Control.Monad.Freer (req)
 import Data.Bifunctor
 import Data.Foldable (foldrM)
+import Data.List (partition)
 import Data.Type.Equality (TestEquality(..), (:~:)(..))
 import qualified Data.Map as M
 import Prelude hiding (last)
@@ -121,13 +122,12 @@ pullPorts toPort showFn (p:ports) types = do
   pull1Port :: PortName
             -> [(a, ty)]
             -> Checking ((a, ty), [(a, ty)])
-  pull1Port p [] = err $ BadPortPull $ "Port not found: " ++ p ++ " in " ++ showFn types
-  pull1Port p (x@(a,_):xs)
-   | p == toPort a
-   = if p `elem` (toPort . fst <$> xs)
-     then err (AmbiguousPortPull p (showFn (x:xs)))
-     else pure (x, xs)
-   | otherwise = second (x:) <$> pull1Port p xs
+  pull1Port p available = case partition ((== p) . toPort . fst) available of
+      ([], _) -> err $ BadPortPull $ "Port not found: " ++ p ++ " in " ++ showFn available
+      ([found], remaining) -> pure (found, remaining)
+      -- this is not quite a refactor: we used to show only the suffix
+      -- of 'available' beginning with the first match
+      (_, _) -> err $ AmbiguousPortPull p (showFn available)
 
 ensureEmpty :: Show ty => String -> [(NamedPort e, ty)] -> Checking ()
 ensureEmpty _ [] = pure ()


### PR DESCRIPTION
Not quite a refactor - change `fail` to a `BadPortPull` error, and slight change to the error message for AmbiguousPortPull (now includes preceding but irrelevant/non-pulled ports)