### PR TITLE
fix BadPortPull error message; refactor pullPorts not to require tuple

### DIFF
--- a/brat/Brat/Checker/Helpers.hs
+++ b/brat/Brat/Checker/Helpers.hs
@@ -121,7 +121,7 @@ pullPorts toPort showFn to_pull types =
  where
   pull1Port :: PortName -> StateT [a] Checking a
   pull1Port p = StateT $ \available -> case partition ((== p) . toPort) available of
-      ([], _) -> err $ BadPortPull $ "Port not found: " ++ p ++ " in " ++ showFn available
+      ([], _) -> err $ BadPortPull p (showFn available)
       ([found], remaining) -> pure (found, remaining)
       (_, _) -> err $ AmbiguousPortPull p (showFn available)
 

--- a/brat/Brat/Checker/SolvePatterns.hs
+++ b/brat/Brat/Checker/SolvePatterns.hs
@@ -372,7 +372,7 @@ argProblems srcs na p = argProblemsWithLeftovers srcs na p >>= \case
   _ -> err $ UnificationError "Pattern doesn't match expected length for constructor args"
 
 argProblemsWithLeftovers :: [Src] -> NormalisedAbstractor -> Problem -> Checking (Problem, [Src])
-argProblemsWithLeftovers srcs (NA (APull ps abs)) p = pullPorts portName show ps (map (, ()) srcs) >>= \srcs -> argProblemsWithLeftovers (fst <$> srcs) (NA abs) p
+argProblemsWithLeftovers srcs (NA (APull ps abs)) p = pullPorts portName show ps srcs >>= \srcs -> argProblemsWithLeftovers srcs (NA abs) p
 argProblemsWithLeftovers (src:srcs) na p | Just (pat, na) <- unconsNA na = first ((src, pat):) <$> argProblemsWithLeftovers srcs na p
 argProblemsWithLeftovers srcs (NA AEmpty) p = pure (p, srcs)
 argProblemsWithLeftovers [] abst _ = err $ NothingToBind (show abst)

--- a/brat/Brat/Error.hs
+++ b/brat/Brat/Error.hs
@@ -61,7 +61,7 @@ data ErrorMsg
  | SymbolNotFound String String
  | InternalError String
  | AmbiguousPortPull String String
- | BadPortPull String
+ | BadPortPull String String
  | VConNotFound String
  | TyConNotFound String String
  | MatchingOnTypes
@@ -139,7 +139,7 @@ instance Show ErrorMsg where
   show (SymbolNotFound s i) = "Symbol `" ++ s ++ "` not found in `" ++ i ++ "`"
   show (InternalError x) = "Internal error: " ++ x
   show (AmbiguousPortPull p row) = "Port " ++ p ++ " is ambiguous in " ++ row
-  show (BadPortPull x) = "Port " ++ x ++ " can't be pulled because it depends on a previous port"
+  show (BadPortPull p row) = "Port not found: " ++ p ++ " in " ++ row
   show (VConNotFound x) = "Value constructor not recognised: " ++ x
   show (TyConNotFound ty v) = show v ++ " is not a valid constructor for type " ++ ty
   show MatchingOnTypes = "Trying to pattern match on a type"

--- a/brat/Brat/Error.hs
+++ b/brat/Brat/Error.hs
@@ -9,6 +9,7 @@ module Brat.Error (ParseError(..)
                   ) where
 
 import Brat.FC
+import Brat.Syntax.Port (PortName)
 
 import Data.List (intercalate)
 import System.Exit
@@ -60,8 +61,8 @@ data ErrorMsg
  | FileNotFound String [String]
  | SymbolNotFound String String
  | InternalError String
- | AmbiguousPortPull String String
- | BadPortPull String String
+ | AmbiguousPortPull PortName String
+ | BadPortPull PortName String
  | VConNotFound String
  | TyConNotFound String String
  | MatchingOnTypes


### PR DESCRIPTION
Slight extra effort in two callsites (`id` -> `fst` is no effort really, so adding a `. fst` in one callsite) seems more than justified with the simplification in the third callsite (in SolvePatterns) and to the type signature of pullPorts.

It's tempting at this point to drop the "port" nomenclature and just call it "pullToFront" (and parametrize by the "port" type), but given we are using errors called BadPortPull and AmbiguousPortPull, let's keep the naming consistent with those. However, fix the BadPortPull error/message, slightly bodged up in #62 