### PR TITLE
tests: fix parsing of karlheinz.brat; extend let.brat

### DIFF
--- a/brat/examples/karlheinz.brat
+++ b/brat/examples/karlheinz.brat
@@ -89,7 +89,7 @@ answer = energy(results)
 evaluate(obs :: Observable
         ,q :: Quantity
         ,a :: Ansatz
-        ,rs :: List Real
+        ,rs :: List(Real)
         ) -> Real
 evaluate = ?eval
 

--- a/brat/examples/let.brat
+++ b/brat/examples/let.brat
@@ -32,3 +32,13 @@ nums' = let xs = map(inc, [0,2,3]) in xs
 
 nums'' :: List(Int)
 nums'' = let i2 = {inc; inc} in map(i2, xs)
+
+dyad :: Int, Bool
+dyad = 42, true
+
+bind2 :: Bool
+bind2 = let i, b = dyad in b
+
+-- It shouldn't matter if we put brackets in the binding sites
+bind2' :: Bool
+bind2' = let (i, b) = dyad in b

--- a/brat/test/Test/Checking.hs
+++ b/brat/test/Test/Checking.hs
@@ -12,6 +12,7 @@ import Test.Tasty.HUnit
 import Test.Tasty.Silver
 
 expectedCheckingFails = map ("examples" </>) ["nested-abstractors.brat"
+                                             ,"karlheinz.brat"
                                              ,"karlheinz_alias.brat"
                                              ,"hea.brat"
                                              ]

--- a/brat/test/Test/Parsing.hs
+++ b/brat/test/Test/Parsing.hs
@@ -15,9 +15,7 @@ testParse file = testCase (show file) $ do
     Left err -> assertFailure (show err)
     Right _ -> return () -- OK
 
-expectedParsingFails = map ("examples" </>) [
-    "karlheinz.brat",
-    "thin.brat"]
+expectedParsingFails = ["examples" </> "thin.brat"]
 
 parseXF = expectFailForPaths expectedParsingFails testParse
 


### PR DESCRIPTION
Both pulled out from #68 as they work fine without it