### PR TITLE
refactor: avoid `Bwd` in `within` and `brackets(Worker)`

### DIFF
--- a/brat/Brat/Lexer/Bracketed.hs
+++ b/brat/Brat/Lexer/Bracketed.hs
@@ -93,14 +93,11 @@ within ctx@(_, b) (t:ts)
  | otherwise = (\(fc, acc, rem) -> (fc, (FlatTok t):acc, rem)) <$> within ctx ts
 
 brackets :: [Token] -> Either Error [BToken]
-brackets ts = bracketsWorker ts
- where
-  bracketsWorker :: [Token] -> Either Error [BToken]
-  bracketsWorker [] = pure []
-  bracketsWorker (t:ts)
-   | Just b <- opener (_tok t) = do
-       (closeFC, xs, ts) <- within (fc t, b) ts
-       let enclosingFC = spanFC (fc t) closeFC
-       ((Bracketed enclosingFC b xs):) <$> bracketsWorker ts
-   | Just b <- closer (_tok t) = Left $ unexpectedCloseErr (fc t) b
-   | otherwise = ((FlatTok t):) <$> bracketsWorker ts
+brackets [] = pure []
+brackets (t:ts)
+  | Just b <- opener (_tok t) = do
+      (closeFC, xs, ts) <- within (fc t, b) ts
+      let enclosingFC = spanFC (fc t) closeFC
+      ((Bracketed enclosingFC b xs):) <$> brackets ts
+  | Just b <- closer (_tok t) = Left $ unexpectedCloseErr (fc t) b
+  | otherwise = ((FlatTok t):) <$> brackets ts

--- a/brat/Brat/Lexer/Bracketed.hs
+++ b/brat/Brat/Lexer/Bracketed.hs
@@ -72,6 +72,9 @@ openCloseMismatchErr open (fcClose, bClose)
 unexpectedCloseErr :: FC -> BracketType -> Error
 unexpectedCloseErr fc b = Err (Just fc) (BracketErr (UnexpectedClose b))
 
+second3 :: (b -> d) -> (a,b,c) -> (a,d,c)
+second3 f (a,b,c) = (a, f b, c)
+
 -- Parse between two brackets of the same type
 within :: (FC, BracketType) -- The nearest opening bracket to the left of us
        -> [Token]    -- The tokens to the right of us, unparsed
@@ -87,10 +90,9 @@ within ctx@(_, b) (t:ts)
  | Just b' <- opener (_tok t) = do
      let innerOpenFC = fc t
      (innerCloseFC, xs, ts) <- within (innerOpenFC, b') ts
-     let fc' = spanFC innerOpenFC innerCloseFC
-     (fc, acc, remaining) <- within ctx ts
-     pure (fc, (Bracketed fc' b' xs):acc, remaining)
- | otherwise = (\(fc, acc, rem) -> (fc, (FlatTok t):acc, rem)) <$> within ctx ts
+     let fc = spanFC innerOpenFC innerCloseFC
+     (second3 ((Bracketed fc b' xs):)) <$> within ctx ts
+ | otherwise = (second3 ((FlatTok t):)) <$> within ctx ts
 
 brackets :: [Token] -> Either Error [BToken]
 brackets [] = pure []

--- a/brat/Brat/Lexer/Bracketed.hs
+++ b/brat/Brat/Lexer/Bracketed.hs
@@ -5,6 +5,7 @@ import Brat.Error (BracketErrMsg(..), Error(Err), ErrorMsg(..))
 import Brat.FC
 import Brat.Lexer.Token
 
+import Data.Tuple.Extra (second3)
 import Text.Megaparsec (PosState(..), SourcePos(..), TraversableStream(..), VisualStream(..))
 import Text.Megaparsec.Pos (mkPos)
 
@@ -71,9 +72,6 @@ openCloseMismatchErr open (fcClose, bClose)
 
 unexpectedCloseErr :: FC -> BracketType -> Error
 unexpectedCloseErr fc b = Err (Just fc) (BracketErr (UnexpectedClose b))
-
-second3 :: (b -> d) -> (a,b,c) -> (a,d,c)
-second3 f (a,b,c) = (a, f b, c)
 
 -- Parse between two brackets of the same type
 within :: (FC, BracketType) -- The nearest opening bracket to the left of us

--- a/brat/brat.cabal
+++ b/brat/brat.cabal
@@ -106,6 +106,7 @@ library
 
   build-depends:       base < 5,
                        megaparsec >= 9.0.0,
+                       extra,
                        mtl,
                        HUnit,
                        containers,


### PR DESCRIPTION
I had a bit of a go at #68 ;)...

The Bwd is just building up a return value; if we just use the stack instead (i.e. `<$>`) then we avoid having to reverse the list. This simplifies `within` a bit (no need to pass `acc`), and simplifies `bracketsWorker` substantially (making `brackets` == `bracketsWorker`).

Individual commits compile so you can see the steps.

It's a shame not to be able to combine `within` and `brackets` because they are very very similar (the `| Just b <- opener (_tok t) = do` case in particular); I tried using a `Maybe (FC, BracketType)` for `ctx` and that almost did it but doesn't copy with `within` needing extra return values :-(. (One could have a `Maybe` return value, and "contract" that Just-in-means-Just-out, I suppose; but really you'd need a type class which is gonna be tooooo much boilerplate)