### PR TITLE
Better Dot rendering of closures

### DIFF
--- a/brat/Brat/Compiler.hs
+++ b/brat/Brat/Compiler.hs
@@ -60,8 +60,8 @@ writeDot :: [FilePath] -> String -> String -> IO ()
 writeDot libDirs file out = do
   env <- runExceptT $ loadFilename root libDirs file
   -- Discard captureSets; perhaps we could incorporate into the graph
-  (_, _, _, graph, _) <- eitherIO env
-  writeFile out (toDotString graph)
+  (_, _, _, graph, cs) <- eitherIO env
+  writeFile out (toDotString graph cs)
 {-
  where
   isMain (PrefixName [] "main", _) = True

--- a/brat/Brat/Dot.hs
+++ b/brat/Brat/Dot.hs
@@ -40,7 +40,6 @@ instance Show EdgeType where
 toDotString :: Graph -> CaptureSets -> String
 toDotString (ns,ws) cs = unpack . GV.printDotGraph $ GV.graphElemsToDot params verts edges
  where
-  _ = cs
   verts :: [(Name', Node)]
   verts = first Name' <$> M.toList ns
 

--- a/brat/Brat/Dot.hs
+++ b/brat/Brat/Dot.hs
@@ -57,8 +57,8 @@ toDotString (ns,ws) cs = unpack . GV.printDotGraph $ GV.graphElemsToDot params v
   getRefEdge x (BratNode (Box src tgt) _ _) = [(x, Name' src, SrcEdge), (x, Name' tgt, SrcEdge)]
   getRefEdge _ _ = []
 
-  -- Map from node to cluster. Clusters are named after the Src node of the box.
-  clusterMap :: M.Map Name' String
+  -- Map from node to cluster. Clusters are identified by their containing Box node.
+  clusterMap :: M.Map Name' Name
   clusterMap = foldr f M.empty verts
    where
     (g, toNode, toVert) = toGraph (ns, ws)
@@ -74,12 +74,11 @@ toDotString (ns,ws) cs = unpack . GV.printDotGraph $ GV.graphElemsToDot params v
           captures = fromMaybe M.empty (M.lookup boxNode cs)
           captureNodes = S.fromList [n | vs <- M.elems captures, (NamedPort (Ex n _) _, _) <- vs]
           nodesInBox = [Name' n | n <- nodesUsedInBox, S.notMember n captureNodes]
-          cluster = show src
-      in foldr (`M.insert` cluster) m nodesInBox
+      in foldr (`M.insert` boxNode) m nodesInBox
     f _ m = m
 
   -- GV.GraphVisParams vertexType vertexLabelType edgeLabelType clusterType clusterLabelType
-  params :: GV.GraphvizParams Name' Node EdgeType String Node
+  params :: GV.GraphvizParams Name' Node EdgeType Name Node
   params = GV.defaultParams {
     GV.fmtNode = \(Name' name, node) -> [
       GV.textLabel (pack $ show name ++ ":\\n" ++ showNodeType node),
@@ -96,7 +95,7 @@ toDotString (ns,ws) cs = unpack . GV.printDotGraph $ GV.graphElemsToDot params v
     GV.clusterBy = \n@(name, _) -> case clusterMap M.!? name of
         Just clust -> GV.C clust $ GV.N n
         Nothing -> GV.N n,
-    GV.clusterID = GV.Str . pack
+    GV.clusterID = GV.Str . pack . show
   }
 
   showNodeType :: Node -> String

--- a/brat/Brat/Dot.hs
+++ b/brat/Brat/Dot.hs
@@ -90,6 +90,9 @@ toDotString (ns,ws) = unpack . GV.printDotGraph $ GV.graphElemsToDot params vert
   }
 
   showNodeType :: Node -> String
+  -- Do not repeat the internal links that have been turned into edges
+  showNodeType (BratNode (Box _ _) _ _) = "Box"
+  showNodeType (BratNode (Eval _) _ _) = "Eval"
   showNodeType (BratNode thing _ _) = show thing
   showNodeType (KernelNode thing _ _) = show thing
 

--- a/brat/Brat/Dot.hs
+++ b/brat/Brat/Dot.hs
@@ -53,23 +53,24 @@ toDotString (ns,ws) = unpack . GV.printDotGraph $ GV.graphElemsToDot params vert
   getRefEdge x (BratNode (Box src tgt) _ _) = [(x, Name' src, SrcEdge), (x, Name' tgt, SrcEdge)]
   getRefEdge _ _ = []
 
-  -- Map all nodes in a box to the src node
-  clusterMap :: M.Map Name' Name'
+  -- Map from node to cluster. Clusters are named after the Src node of the box.
+  clusterMap :: M.Map Name' String
   clusterMap = foldr f M.empty verts
    where
     (g, toNode, toVert) = toGraph (ns, ws)
     f (_, node) m = case node of
       BratNode (Box src tgt) _ _ ->
         -- Find all nodes in the box spanned by src and tgt, i.e. all nodes
-        -- reachable from src that can reach tgt
+        -- reachable from src *or* that can reach tgt
         let srcReaches = reachable g (fromJust (toVert src))
             reachesTgt = reachable (transposeG g) (fromJust (toVert tgt))
-            box = Name' . snd3 . toNode <$> (srcReaches ++ reachesTgt) in
-        foldr (`M.insert` Name' src) m box
+            nodesInBox = Name' . snd3 . toNode <$> (srcReaches ++ reachesTgt)
+            cluster = show src
+        in foldr (`M.insert` cluster) m nodesInBox
       _ -> m
 
   -- GV.GraphVisParams vertexType vertexLabelType edgeLabelType clusterType clusterLabelType
-  params :: GV.GraphvizParams Name' Node EdgeType Name' Node
+  params :: GV.GraphvizParams Name' Node EdgeType String Node
   params = GV.defaultParams {
     GV.fmtNode = \(Name' name, node) -> [
       GV.textLabel (pack $ show name ++ ":\\n" ++ showNodeType node),
@@ -84,9 +85,9 @@ toDotString (ns,ws) = unpack . GV.printDotGraph $ GV.graphElemsToDot params vert
       GV.arrowTo (arrow label)
     ],
     GV.clusterBy = \n@(name, _) -> case clusterMap M.!? name of
-        Just parent -> GV.C parent $ GV.N n
+        Just clust -> GV.C clust $ GV.N n
         Nothing -> GV.N n,
-    GV.clusterID = \(Name' name) -> GV.Str (pack $ show name)
+    GV.clusterID = GV.Str . pack
   }
 
   showNodeType :: Node -> String

--- a/brat/Brat/Dot.hs
+++ b/brat/Brat/Dot.hs
@@ -92,11 +92,15 @@ toDotString (ns,ws) cs = unpack . GV.printDotGraph $ GV.graphElemsToDot params v
       GV.Style [style label],
       GV.arrowTo (arrow label)
     ],
-    GV.clusterBy = \n@(name, _) -> case clusterMap M.!? name of
-        Just clust -> GV.C clust $ GV.N n
-        Nothing -> GV.N n,
+    GV.clusterBy = \n@(name, _) -> nestClusters name (GV.N n),
     GV.clusterID = GV.Str . pack . show
   }
+
+  nestClusters :: Name' -> GV.NodeCluster Name (Name', Node) -> GV.NodeCluster Name (Name', Node)
+  nestClusters name n = case clusterMap M.!? name of
+    Nothing -> n
+    -- put n in clust, which may itself be in another cluster
+    Just clust -> nestClusters (Name' clust) (GV.C clust n)
 
   showNodeType :: Node -> String
   -- Do not repeat the internal links that have been turned into edges

--- a/brat/Brat/Dot.hs
+++ b/brat/Brat/Dot.hs
@@ -1,5 +1,6 @@
 module Brat.Dot (toDotString) where
 
+import Brat.Checker.Monad (CaptureSets)
 import Brat.Naming
 import Brat.Graph
 import Brat.Syntax.Common
@@ -11,7 +12,9 @@ import qualified Data.GraphViz.Printing as GV
 import qualified Data.GraphViz.Attributes.Complete as GV
 
 import qualified Data.Map as M
+import qualified Data.Set as S
 import Data.Text.Lazy (pack, unpack)
+import Data.Maybe (fromMaybe)
 import Data.Bifunctor (first)
 import Data.Graph (reachable, transposeG)
 import Data.Maybe (fromJust)
@@ -34,9 +37,10 @@ instance Show EdgeType where
   show (GraphEdge ty) = show ty
 
 
-toDotString :: Graph -> String
-toDotString (ns,ws) = unpack . GV.printDotGraph $ GV.graphElemsToDot params verts edges
+toDotString :: Graph -> CaptureSets -> String
+toDotString (ns,ws) cs = unpack . GV.printDotGraph $ GV.graphElemsToDot params verts edges
  where
+  _ = cs
   verts :: [(Name', Node)]
   verts = first Name' <$> M.toList ns
 
@@ -58,16 +62,21 @@ toDotString (ns,ws) = unpack . GV.printDotGraph $ GV.graphElemsToDot params vert
   clusterMap = foldr f M.empty verts
    where
     (g, toNode, toVert) = toGraph (ns, ws)
-    f (_, node) m = case node of
-      BratNode (Box src tgt) _ _ ->
-        -- Find all nodes in the box spanned by src and tgt, i.e. all nodes
-        -- reachable from src *or* that can reach tgt
-        let srcReaches = reachable g (fromJust (toVert src))
-            reachesTgt = reachable (transposeG g) (fromJust (toVert tgt))
-            nodesInBox = Name' . snd3 . toNode <$> (srcReaches ++ reachesTgt)
-            cluster = show src
-        in foldr (`M.insert` cluster) m nodesInBox
-      _ -> m
+    f (Name' boxNode, BratNode (Box src tgt) _ _) m =
+      -- Find all nodes in the box spanned by src and tgt, i.e. all nodes
+      -- reachable from src that can reach tgt
+      let srcReaches = reachable g (fromJust (toVert src))
+          reachesTgt = reachable (transposeG g) (fromJust (toVert tgt))
+          nodesUsedInBox = snd3 . toNode <$> (srcReaches ++ reachesTgt)
+          -- exclude nodes that are captured by the box - these are not in the box
+          -- (TODO: we might consider adding extra edges from these to the box itself,
+          --  but for now they'll just have "normal" value edges *entering* the box)
+          captures = fromMaybe M.empty (M.lookup boxNode cs)
+          captureNodes = S.fromList [n | vs <- M.elems captures, (NamedPort (Ex n _) _, _) <- vs]
+          nodesInBox = [Name' n | n <- nodesUsedInBox, S.notMember n captureNodes]
+          cluster = show src
+      in foldr (`M.insert` cluster) m nodesInBox
+    f _ m = m
 
   -- GV.GraphVisParams vertexType vertexLabelType edgeLabelType clusterType clusterLabelType
   params :: GV.GraphvizParams Name' Node EdgeType String Node

--- a/brat/Brat/Dot.hs
+++ b/brat/Brat/Dot.hs
@@ -50,7 +50,7 @@ toDotString (ns,ws) = unpack . GV.printDotGraph $ GV.graphElemsToDot params vert
   getRefEdge :: Name' -> Node -> [(Name', Name', EdgeType)]
   getRefEdge x (BratNode (Eval (Ex y _)) _ _) = [(Name' y, x, EvalEdge)]
   getRefEdge x (KernelNode (Splice (Ex y _)) _ _) = [(Name' y, x, EvalEdge)]
-  getRefEdge x (BratNode (Box src _) _ _) = [(x, Name' src, SrcEdge)]
+  getRefEdge x (BratNode (Box src tgt) _ _) = [(x, Name' src, SrcEdge), (x, Name' tgt, SrcEdge)]
   getRefEdge _ _ = []
 
   -- Map all nodes in a box to the src node

--- a/brat/test/compilation/closures.brat
+++ b/brat/test/compilation/closures.brat
@@ -1,17 +1,2 @@
 f(Nat) -> { Nat -> Nat }
 f(x) = { y => x + y }
-
-g(Nat) -> { Nat -> { Nat -> Nat } }
-g(x) = { y => { z => x + y + z } }
-
-
-h(Nat) -> { Nat -> Nat }
-h(x) = let y = x in { z => x + y + z }
-
-ff(Vec(Nat,2)) -> { Nat -> Nat }
-ff([a,b]) = { y => a + b*y }
-
-ext "to_float" i2f :: {Int -> Float}
-
-fi(Float) -> { Int -> Float }
-fi(x) = { y => x + i2f(y) }


### PR DESCRIPTION
closes #101 - the BRAT graph is fine, it was just the rendering that was terrible.

* Exclude nodes captured by a box from being in the box. This was how multiple Sources were ending up in the same box as a Target. Instead each Source should now end up in the same box as its Target.
* Add edge from Box node to Target. This is probably redundant now I have properly fixed the previous.
* Shorten rendering of labels: "Box sourcenodename targetnodename" is now just "Box", similarly Eval. The names are redundant as they are shown by the dotted edges. (So maybe the Box-Target edge does have a purpose, allowing label to be shortened?)
* Properly nest clusters, i.e. when a Box node B1 is in a cluster C1, the associated cluster C2 with B1's Source+Target should now be a subcluster of C2

This piccy demonstrates effect on function `f` in `closures.brat`, admittedly for the pic I also shortened PatternMatch but really we need to handle those properly - a TODO for a followup

<img width="2132" height="550" alt="image" src="https://github.com/user-attachments/assets/b964a30a-7fbb-471c-889f-680180fc4a84" />

Previously the middle (between left and right) Source had been put in the LHS cluster, causing the confusion, and of course the clusters were not nested.