### PR TITLE
Better dot rendering of PatternMatch

### DIFF
--- a/brat/Brat/Compiler.hs
+++ b/brat/Brat/Compiler.hs
@@ -66,7 +66,6 @@ printAST printRaw printAST file = do
 writeDot :: [FilePath] -> String -> String -> IO ()
 writeDot libDirs file out = do
   env <- runExceptT $ loadFilename root libDirs file
-  -- Discard captureSets; perhaps we could incorporate into the graph
   (_, _, _, graph, cs) <- eitherIO env
   writeFile out (toDotString graph cs)
 {-

--- a/brat/Brat/Dot.hs
+++ b/brat/Brat/Dot.hs
@@ -65,16 +65,16 @@ toDotString (ns,ws) cs = unpack . GV.printDotGraph $ GV.graphElemsToDot params v
   clusterMap = foldr f M.empty verts
    where
     (g, toNode, toVert) = toGraph (ns, ws)
-    f (Name' patNode, BratNode (PatternMatch pats) _ _) m =
-      -- Put the boxes for each case in a cluster for the whole PatternMatch.
-      -- (This will be nested inside whatever cluster the PatternMatch node is in.)
-      foldr (\(_, innerBox) -> M.insert (Name' innerBox) patNode) m pats
     f (Name' boxNode, BratNode (Box src tgt) _ _) m =
       -- Find all nodes in the box spanned by src and tgt, i.e. all nodes
       -- reachable from src that can reach tgt
       let srcReaches = reachable g (fromJust (toVert src))
           reachesTgt = reachable (transposeG g) (fromJust (toVert tgt))
-          nodesUsedInBox = snd3 . toNode <$> (srcReaches ++ reachesTgt)
+          nodesReachedInBox = snd3 . toNode <$> (srcReaches ++ reachesTgt)
+          -- Add any Box nodes used by PatternMatch nodes in the cluster
+          matches = M.fromList [(n, p:ps) | n <- nodesReachedInBox,
+                                            Just (BratNode (PatternMatch (p:|ps)) _ _) <- [ns M.!? n]]
+          nodesUsedInBox = nodesReachedInBox ++ map snd (concat (M.elems matches))
           -- exclude nodes that are captured by the box - these are not in the box
           -- (TODO: we might consider adding extra edges from these to the box itself,
           --  but for now they'll just have "normal" value edges *entering* the box)

--- a/brat/Brat/Dot.hs
+++ b/brat/Brat/Dot.hs
@@ -29,11 +29,12 @@ instance (GV.PrintDot Name') where
   toDot  (Name' name) =  GV.text . pack $ "\"" ++ show name ++ "\""
 
 
-data EdgeType = EvalEdge | SrcEdge | GraphEdge (Val Z)
+data EdgeType = EvalEdge | SrcEdge | CaseEdge | GraphEdge (Val Z)
 
 instance Show EdgeType where
   show EvalEdge = ""
   show SrcEdge = ""
+  show CaseEdge = ""
   show (GraphEdge ty) = show ty
 
 
@@ -54,6 +55,8 @@ toDotString (ns,ws) cs = unpack . GV.printDotGraph $ GV.graphElemsToDot params v
   getRefEdge x (BratNode (Eval (Ex y _)) _ _) = [(Name' y, x, EvalEdge)]
   getRefEdge x (KernelNode (Splice (Ex y _)) _ _) = [(Name' y, x, EvalEdge)]
   getRefEdge x (BratNode (Box src tgt) _ _) = [(x, Name' src, SrcEdge), (x, Name' tgt, SrcEdge)]
+  getRefEdge x (BratNode (PatternMatch (p:|pats)) _ _) =
+    [ (x, Name' innerBox, CaseEdge) | (_, innerBox) <- (p:pats) ]
   getRefEdge _ _ = []
 
   -- Map from node to cluster. Clusters are identified by their containing Box node.

--- a/brat/Brat/Dot.hs
+++ b/brat/Brat/Dot.hs
@@ -108,6 +108,7 @@ toDotString (ns,ws) cs = unpack . GV.printDotGraph $ GV.graphElemsToDot params v
   -- Do not repeat the internal links that have been turned into edges
   showNodeType (BratNode (Box _ _) _ _) = "Box"
   showNodeType (BratNode (Eval _) _ _) = "Eval"
+  showNodeType (BratNode (PatternMatch _) _ _) = "PatternMatch"
   showNodeType (BratNode thing _ _) = show thing
   showNodeType (KernelNode thing _ _) = show thing
 

--- a/brat/Brat/Dot.hs
+++ b/brat/Brat/Dot.hs
@@ -13,6 +13,7 @@ import qualified Data.GraphViz.Attributes.Complete as GV
 
 import qualified Data.Map as M
 import qualified Data.Set as S
+import Data.List.NonEmpty (NonEmpty(..))
 import Data.Text.Lazy (pack, unpack)
 import Data.Maybe (fromMaybe)
 import Data.Bifunctor (first)
@@ -64,6 +65,10 @@ toDotString (ns,ws) cs = unpack . GV.printDotGraph $ GV.graphElemsToDot params v
   clusterMap = foldr f M.empty verts
    where
     (g, toNode, toVert) = toGraph (ns, ws)
+    f (Name' patNode, BratNode (PatternMatch pats) _ _) m =
+      -- Put the boxes for each case in a cluster for the whole PatternMatch.
+      -- (This will be nested inside whatever cluster the PatternMatch node is in.)
+      foldr (\(_, innerBox) -> M.insert (Name' innerBox) patNode) m pats
     f (Name' boxNode, BratNode (Box src tgt) _ _) m =
       -- Find all nodes in the box spanned by src and tgt, i.e. all nodes
       -- reachable from src that can reach tgt

--- a/brat/test/compilation/closures.brat
+++ b/brat/test/compilation/closures.brat
@@ -1,2 +1,17 @@
 f(Nat) -> { Nat -> Nat }
 f(x) = { y => x + y }
+
+g(Nat) -> { Nat -> { Nat -> Nat } }
+g(x) = { y => { z => x + y + z } }
+
+
+h(Nat) -> { Nat -> Nat }
+h(x) = let y = x in { z => x + y + z }
+
+ff(Vec(Nat,2)) -> { Nat -> Nat }
+ff([a,b]) = { y => a + b*y }
+
+ext "to_float" i2f :: {Int -> Float}
+
+fi(Float) -> { Int -> Float }
+fi(x) = { y => x + i2f(y) }


### PR DESCRIPTION
Similar to #117:
* add edges from PatternMatch to each Box node it mentions
* remove the now-redundant info in the label (OK this also removes detail of what tests are applied - are we happy?)
* Include Boxes owned by a PatternMatch node as siblings of the latter. (The Source+Target and rest will thus be a subcluster)

Also reinstate closures.dot accidentally smashed by #117 :-(

closures.brat `f` is now:
<img width="5999" height="1003" alt="f" src="https://github.com/user-attachments/assets/331e0c74-30c7-4cb3-a6f8-49c0f25447d7" />

which I think is an improvement

And g:
<img width="11425" height="1299" alt="g" src="https://github.com/user-attachments/assets/a0e6e46a-84c6-4795-b4ac-b67999b1dbb1" />

Note the "_lhs...._setup" boxes that are not in the hierarchy of the rest of the graph, created here: https://github.com/Quantinuum/brat/blob/88e8617815181115f3abc944e844bca86467a21e/brat/Brat/Checker.hs#L738-L758